### PR TITLE
feat: Electron desktop shell (macOS / Windows / Linux)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,13 +183,23 @@ Bundle and package it:
 
 ```sh
 pnpm --filter @boardown/electron build   # main + preload (esbuild) + renderer (Vite) → dist/
-pnpm --filter @boardown/electron dist    # OS installers via electron-builder → release/
+pnpm --filter @boardown/electron dist    # package for the current OS via electron-builder → release/
 ```
 
 `pnpm install` downloads the Electron binary automatically (it is allow-listed in
-the root `pnpm.onlyBuiltDependencies`). Producing _signed, notarized_ installers
-for all three OSes is a release-pipeline concern (Apple notarization, Windows
-code-signing) and belongs in CI, not in a local `dist` build.
+the root `pnpm.onlyBuiltDependencies`).
+
+**Per OS** — `electron-builder` packages for the **host OS**, so run `dist` on the
+OS you're targeting (or in a CI matrix, one runner per OS):
+
+- **macOS** → `.dmg` + `.zip`
+- **Windows** → a `.zip` (no installer — unzip and run `boardown.exe`)
+- **Linux** → `.AppImage` (run directly) + `.deb`
+
+Cross-building from another OS is fiddly (Windows would need Wine), so a CI matrix
+is the reliable path for all three. Signed / notarized artifacts (Apple
+notarization, Windows code-signing) need certificates and belong in that CI step,
+not a local build.
 
 ### Sample board for the dev server
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Install dependencies once if you skipped the quick start above:
 pnpm install
 ```
 
-The repo is a pnpm workspace with four packages:
+The repo is a pnpm workspace with five packages:
 
 - [`packages/core`](./packages/core) — platform-agnostic logic (schemas,
   parser, board operations). Pure TypeScript, runs in Node.
@@ -120,8 +120,10 @@ The repo is a pnpm workspace with four packages:
   a VS Code extension shell next to `web` (extension host via esbuild + webview
   via Vite), reusing `@boardown/ui` unchanged. Packages into an installable
   `.vsix` (see [Building the `.vsix` from sources](#building-the-vsix-from-sources) above).
-
-A `packages/electron` shell is post-MVP.
+- [`packages/electron`](./packages/electron) — a cross-platform desktop shell
+  (macOS / Windows / Linux): an Electron main process + preload behind the same
+  `FsAdapter`, with a Vite-built renderer that reuses `@boardown/ui`. See
+  [Desktop app (Electron)](#desktop-app-electron) below.
 
 ### Common scripts (run from the repo root)
 
@@ -160,6 +162,34 @@ pnpm dev -- --data-dir /path/to/project/.boardown
 If `--data-dir` is omitted, boardown uses this repository's `.boardown/`, same
 as before. Relative `--data-dir` paths are resolved from the directory where
 you run the command.
+
+### Desktop app (Electron)
+
+`packages/electron` is a cross-platform desktop build (macOS / Windows / Linux).
+It reuses `@boardown/ui` unchanged behind an Electron `FsAdapter` and boots to a
+sidebar of recent project folders — pick one, or **Open Folder…**, and the board
+loads from that folder's `.boardown/`.
+
+Run it from sources in dev (Vite HMR for the renderer, esbuild watch for the main
+process and preload):
+
+```sh
+pnpm --filter @boardown/electron dev
+# open a specific folder on launch:
+pnpm --filter @boardown/electron dev -- /path/to/project
+```
+
+Bundle and package it:
+
+```sh
+pnpm --filter @boardown/electron build   # main + preload (esbuild) + renderer (Vite) → dist/
+pnpm --filter @boardown/electron dist    # OS installers via electron-builder → release/
+```
+
+`pnpm install` downloads the Electron binary automatically (it is allow-listed in
+the root `pnpm.onlyBuiltDependencies`). Producing _signed, notarized_ installers
+for all three OSes is a release-pipeline concern (Apple notarization, Windows
+code-signing) and belongs in CI, not in a local `dist` build.
 
 ### Sample board for the dev server
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -31,7 +31,7 @@ export default tseslint.config(
     },
   },
   {
-    files: ['packages/{web,ui,vscode}/**/*.{ts,tsx}'],
+    files: ['packages/{web,ui,vscode,electron}/**/*.{ts,tsx}'],
     ...react.configs.flat.recommended,
     ...react.configs.flat['jsx-runtime'],
     languageOptions: {
@@ -45,7 +45,7 @@ export default tseslint.config(
     },
   },
   {
-    files: ['packages/{web,ui,vscode}/**/*.{ts,tsx}'],
+    files: ['packages/{web,ui,vscode,electron}/**/*.{ts,tsx}'],
     plugins: { 'react-hooks': reactHooks },
     rules: reactHooks.configs.recommended.rules,
   },

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "packageManager": "pnpm@10.33.3",
   "pnpm": {
     "onlyBuiltDependencies": [
+      "electron",
       "esbuild"
     ]
   },

--- a/packages/electron/.gitignore
+++ b/packages/electron/.gitignore
@@ -1,0 +1,2 @@
+# electron-builder output
+release/

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -1,0 +1,41 @@
+# @boardown/electron
+
+Cross-platform desktop shell for boardown (macOS / Windows / Linux). A sibling of
+the `web` and `vscode` shells: it reuses `@boardown/ui` unchanged and only
+provides the platform layer — an `FsAdapter` over Electron IPC, an OS-native
+folder picker, a recent-folders list, and the application menu.
+
+## How it fits the architecture
+
+- **Main process** (`src/main/`, bundled with esbuild → `dist/main.js`,
+  `dist/preload.js`) owns all OS integration: window lifecycle, the native
+  `Open Folder…` dialog, recent-folders persistence (in `app.getPath('userData')`),
+  the menu, an optional CLI folder argument, and the file-system IPC handlers.
+  Every path is resolved against the open board's `.boardown/` directory and
+  guarded against `..`/absolute-path escapes.
+- **Preload** (`src/main/preload.ts`) exposes a single `window.boardown` bridge
+  via `contextBridge` (context isolation on, no node integration, sandboxed).
+- **Renderer** (`src/renderer/`, bundled with Vite → `dist/renderer/`) shows a
+  welcome screen (recent folders + Open Folder) until a board is chosen, then
+  mounts the real `@boardown/ui` `App` with the bridge's `FsAdapter`.
+
+The board root is `<chosen folder>/.boardown/` — the same convention the VS Code
+shell uses for its workspace folder.
+
+## Scripts
+
+- `pnpm --filter @boardown/electron dev` — Vite dev server + esbuild watch +
+  Electron pointed at it. Append `-- /path/to/project` to open a board on boot.
+- `pnpm --filter @boardown/electron build` — bundle main, preload and renderer
+  into `dist/`.
+- `pnpm --filter @boardown/electron dist` — package installers via
+  `electron-builder` (see `electron-builder.yml`).
+
+> Running the app needs the Electron binary, whose download is a pnpm build
+> script. If pnpm reports it as ignored, approve it with `pnpm approve-builds`
+> (or add `electron` to the root `pnpm.onlyBuiltDependencies`). The lint /
+> typecheck / build / test gates do **not** need the binary.
+
+Producing signed, notarized installers for all three OSes is a release-pipeline
+concern (certificates, Apple notarization, Windows code-signing) and lives in
+CI, not in this package.

--- a/packages/electron/electron-builder.yml
+++ b/packages/electron/electron-builder.yml
@@ -4,9 +4,9 @@
 # process + preload, Vite for the renderer), so packaging only ships dist/ and
 # package.json — no node_modules tree.
 #
-# Producing *distributable* installers for all three OSes (code-signing on
-# Windows, Apple notarization on macOS, building the Linux targets on Linux) is
-# a release-pipeline concern owned by the maintainer's CI and its secrets.
+# Producing signed/notarized *builds* for all three OSes (code-signing on
+# Windows, Apple notarization on macOS, each OS built on its own runner) is a
+# release-pipeline concern owned by the maintainer's CI and its secrets.
 # `pnpm --filter @boardown/electron dist` is the local entry point.
 appId: com.boardown.app
 productName: boardown
@@ -22,8 +22,10 @@ mac:
     - dmg
     - zip
 win:
+  # No installer — a plain .zip you unzip and run (boardown.exe). Mirrors the
+  # mac .zip / linux .AppImage "just run it" targets.
   target:
-    - nsis
+    - zip
 linux:
   category: Development
   target:

--- a/packages/electron/electron-builder.yml
+++ b/packages/electron/electron-builder.yml
@@ -1,0 +1,31 @@
+# Packaging config for the boardown desktop app.
+#
+# Everything the app runs is already bundled into dist/ (esbuild for the main
+# process + preload, Vite for the renderer), so packaging only ships dist/ and
+# package.json — no node_modules tree.
+#
+# Producing *distributable* installers for all three OSes (code-signing on
+# Windows, Apple notarization on macOS, building the Linux targets on Linux) is
+# a release-pipeline concern owned by the maintainer's CI and its secrets.
+# `pnpm --filter @boardown/electron dist` is the local entry point.
+appId: com.boardown.app
+productName: boardown
+directories:
+  output: release
+  buildResources: build
+files:
+  - dist/**
+  - package.json
+mac:
+  category: public.app-category.developer-tools
+  target:
+    - dmg
+    - zip
+win:
+  target:
+    - nsis
+linux:
+  category: Development
+  target:
+    - AppImage
+    - deb

--- a/packages/electron/esbuild.mjs
+++ b/packages/electron/esbuild.mjs
@@ -1,0 +1,25 @@
+import esbuild from 'esbuild';
+
+const watch = process.argv.includes('--watch');
+
+// Main process and preload are Node/Electron code: bundle to CJS with electron
+// kept external, exactly like the VS Code host. The renderer is Vite's job.
+/** @type {import('esbuild').BuildOptions} */
+const options = {
+  entryPoints: ['src/main/main.ts', 'src/main/preload.ts'],
+  outdir: 'dist',
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  target: 'node20',
+  external: ['electron'],
+  sourcemap: true,
+};
+
+if (watch) {
+  const ctx = await esbuild.context(options);
+  await ctx.watch();
+  console.log('esbuild: watching main + preload…');
+} else {
+  await esbuild.build(options);
+}

--- a/packages/electron/index.html
+++ b/packages/electron/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>boardown</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/renderer/main.tsx"></script>
+  </body>
+</html>

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@boardown/core": "workspace:*",
     "@boardown/ui": "workspace:*",
+    "lucide-react": "^1.14.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "@boardown/electron",
+  "version": "0.1.0",
+  "private": true,
+  "license": "MIT",
+  "main": "./dist/main.js",
+  "scripts": {
+    "dev": "node scripts/dev.mjs",
+    "build:main": "node esbuild.mjs",
+    "build:renderer": "vite build",
+    "build": "pnpm build:main && pnpm build:renderer",
+    "watch:main": "node esbuild.mjs --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "dist": "pnpm build && electron-builder"
+  },
+  "dependencies": {
+    "@boardown/core": "workspace:*",
+    "@boardown/ui": "workspace:*",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.10",
+    "@types/react": "^18.3.18",
+    "@types/react-dom": "^18.3.5",
+    "@vitejs/plugin-react": "^4.3.4",
+    "electron": "^33.0.0",
+    "electron-builder": "^25.1.8",
+    "esbuild": "^0.24.0",
+    "vite": "^6.0.3",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/electron/scripts/dev.mjs
+++ b/packages/electron/scripts/dev.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+import esbuild from 'esbuild';
+import { createServer } from 'vite';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const pkgRoot = path.resolve(here, '..');
+
+// 1. Renderer dev server (HMR).
+const viteServer = await createServer({ configFile: path.join(pkgRoot, 'vite.config.ts') });
+await viteServer.listen();
+const url = viteServer.resolvedUrls?.local[0];
+if (!url) {
+  console.error('Vite dev server did not report a local URL');
+  process.exit(1);
+}
+
+// 2. Build + watch the main process and preload.
+const ctx = await esbuild.context({
+  entryPoints: [
+    path.join(pkgRoot, 'src/main/main.ts'),
+    path.join(pkgRoot, 'src/main/preload.ts'),
+  ],
+  outdir: path.join(pkgRoot, 'dist'),
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  target: 'node20',
+  external: ['electron'],
+  sourcemap: true,
+});
+await ctx.rebuild();
+await ctx.watch();
+
+// 3. Launch Electron against the dev server. Forward any extra args (e.g. a
+// folder path) after `--` so `pnpm dev -- /path/to/project` opens it on boot.
+const electronBin = (await import('electron')).default;
+const extraArgs = process.argv.slice(2).filter((arg) => arg !== '--');
+const child = spawn(electronBin, [pkgRoot, ...extraArgs], {
+  env: { ...process.env, BOARDOWN_RENDERER_URL: url },
+  stdio: 'inherit',
+});
+
+const shutdown = async () => {
+  await ctx.dispose();
+  await viteServer.close();
+};
+
+child.on('exit', (code) => {
+  void shutdown().finally(() => process.exit(code ?? 0));
+});
+child.on('error', (err) => {
+  console.error(err.message);
+  void shutdown().finally(() => process.exit(1));
+});
+
+// Ctrl+C reaches the whole process group; tear down Vite + esbuild before exit
+// instead of leaking the watcher and the bound dev-server port.
+for (const signal of ['SIGINT', 'SIGTERM']) {
+  process.on(signal, () => {
+    child.kill();
+    void shutdown().finally(() => process.exit(0));
+  });
+}

--- a/packages/electron/src/bridge.ts
+++ b/packages/electron/src/bridge.ts
@@ -2,6 +2,9 @@ import type { FsAdapter, Theme } from '@boardown/core';
 
 export type FsMethod = 'read' | 'write' | 'list' | 'stat';
 
+// App-wide theme setting. 'system' follows the OS; 'light'/'dark' are fixed.
+export type ThemeChoice = 'system' | 'light' | 'dark';
+
 export interface FsRequest {
   method: FsMethod;
   path: string;
@@ -26,6 +29,7 @@ export interface ProjectEntry extends RecentEntry {
 // CLI-supplied folder without a round-trip flash.
 export interface BootstrapState {
   theme: Theme;
+  themeChoice: ThemeChoice;
   initialFolder: string | null;
 }
 
@@ -35,6 +39,8 @@ export interface BootstrapState {
 // the currently open board.
 export interface BoardownBridge {
   readonly theme: Theme;
+  // The user's chosen theme mode, for the settings UI (resolved value = theme).
+  readonly themeChoice: ThemeChoice;
   readonly initialFolder: string | null;
   readonly fs: FsAdapter;
   readonly pickFolder: () => Promise<void>;
@@ -45,6 +51,9 @@ export interface BoardownBridge {
   // Drop a project from the sidebar list (does not touch the folder on disk).
   readonly removeRecent: (folder: string) => Promise<void>;
   readonly getRecents: () => Promise<ProjectEntry[]>;
+  // Change the app-wide theme mode (persisted). The resolved value arrives via
+  // `theme` / onThemeChange; the current mode is `themeChoice`.
+  readonly setThemeChoice: (choice: ThemeChoice) => Promise<void>;
   readonly onBoardOpened: (listener: (folder: string) => void) => () => void;
   readonly onBoardClosed: (listener: () => void) => () => void;
   readonly onThemeChange: (listener: (theme: Theme) => void) => () => void;
@@ -58,6 +67,7 @@ export const IPC = {
   cancelBoard: 'boardown:cancel-board',
   removeRecent: 'boardown:remove-recent',
   getRecents: 'boardown:get-recents',
+  setThemeChoice: 'boardown:set-theme-choice',
   boardOpened: 'boardown:board-opened',
   boardClosed: 'boardown:board-closed',
   themeChanged: 'boardown:theme-changed',

--- a/packages/electron/src/bridge.ts
+++ b/packages/electron/src/bridge.ts
@@ -1,0 +1,70 @@
+import type { FsAdapter, Theme } from '@boardown/core';
+
+export type FsMethod = 'read' | 'write' | 'list' | 'stat';
+
+export interface FsRequest {
+  method: FsMethod;
+  path: string;
+  content?: string;
+}
+
+export interface RecentEntry {
+  folder: string;
+  name: string;
+  lastOpened: number;
+}
+
+// A recent entry enriched for the sidebar: whether the folder already has a
+// board (a .boardown/config.yaml) or still needs onboarding. Not persisted —
+// computed per listing.
+export interface ProjectEntry extends RecentEntry {
+  hasBoard: boolean;
+}
+
+// Synchronous startup state the preload reads before first paint, so the
+// welcome screen and the initial board both render with the right theme and the
+// CLI-supplied folder without a round-trip flash.
+export interface BootstrapState {
+  theme: Theme;
+  initialFolder: string | null;
+}
+
+// The surface exposed on window.boardown by the preload. The renderer talks to
+// this and nothing else — never to Node or Electron APIs directly. `fs` is the
+// plain FsAdapter @boardown/ui consumes; the host resolves every path against
+// the currently open board.
+export interface BoardownBridge {
+  readonly theme: Theme;
+  readonly initialFolder: string | null;
+  readonly fs: FsAdapter;
+  readonly pickFolder: () => Promise<void>;
+  readonly openRecent: (folder: string) => Promise<void>;
+  // Abandon onboarding for the open folder: forget it (drop from recents) and
+  // clear the window's board context.
+  readonly cancelBoard: () => Promise<void>;
+  // Drop a project from the sidebar list (does not touch the folder on disk).
+  readonly removeRecent: (folder: string) => Promise<void>;
+  readonly getRecents: () => Promise<ProjectEntry[]>;
+  readonly onBoardOpened: (listener: (folder: string) => void) => () => void;
+  readonly onBoardClosed: (listener: () => void) => () => void;
+  readonly onThemeChange: (listener: (theme: Theme) => void) => () => void;
+}
+
+export const IPC = {
+  bootstrap: 'boardown:bootstrap',
+  fs: 'boardown:fs',
+  pickFolder: 'boardown:pick-folder',
+  openRecent: 'boardown:open-recent',
+  cancelBoard: 'boardown:cancel-board',
+  removeRecent: 'boardown:remove-recent',
+  getRecents: 'boardown:get-recents',
+  boardOpened: 'boardown:board-opened',
+  boardClosed: 'boardown:board-closed',
+  themeChanged: 'boardown:theme-changed',
+} as const;
+
+declare global {
+  interface Window {
+    boardown: BoardownBridge;
+  }
+}

--- a/packages/electron/src/main/board-fs.test.ts
+++ b/packages/electron/src/main/board-fs.test.ts
@@ -1,0 +1,95 @@
+import { promises as fsp } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { handleFsRequest, resolveTarget } from './board-fs';
+
+const ROOT = path.resolve('/tmp/boardown-test/.boardown');
+
+describe('resolveTarget', () => {
+  it('joins a simple relative path onto the board root', () => {
+    expect(resolveTarget(ROOT, 'config.yaml')).toBe(path.join(ROOT, 'config.yaml'));
+  });
+
+  it('joins a nested relative path', () => {
+    expect(resolveTarget(ROOT, 'releases/2025-01.md')).toBe(
+      path.join(ROOT, 'releases', '2025-01.md'),
+    );
+  });
+
+  it('normalizes backslashes to the path separator', () => {
+    expect(resolveTarget(ROOT, 'releases\\2025-01.md')).toBe(
+      path.join(ROOT, 'releases', '2025-01.md'),
+    );
+  });
+
+  it('rejects an absolute POSIX path', () => {
+    expect(resolveTarget(ROOT, '/etc/passwd')).toBeNull();
+  });
+
+  it('rejects a Windows drive-letter path', () => {
+    expect(resolveTarget(ROOT, 'C:\\Windows\\system32')).toBeNull();
+  });
+
+  it('rejects traversal that escapes the board root', () => {
+    expect(resolveTarget(ROOT, '../../../etc/passwd')).toBeNull();
+  });
+
+  it('rejects traversal embedded in an otherwise relative path', () => {
+    expect(resolveTarget(ROOT, 'releases/../../secret')).toBeNull();
+  });
+
+  it('rejects a leading-".." literal — percent-encoding is no bypass', () => {
+    expect(resolveTarget(ROOT, '..%2F..%2Fsecret')).toBeNull();
+  });
+});
+
+describe('handleFsRequest', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await fsp.mkdtemp(path.join(os.tmpdir(), 'boardown-fs-'));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(root, { recursive: true, force: true });
+  });
+
+  it('write creates parent directories, then read returns the content', async () => {
+    await handleFsRequest(root, { method: 'write', path: 'releases/r.md', content: 'hi' });
+    expect(await handleFsRequest(root, { method: 'read', path: 'releases/r.md' })).toBe('hi');
+  });
+
+  it('list returns [] for a missing directory', async () => {
+    expect(await handleFsRequest(root, { method: 'list', path: 'releases' })).toEqual([]);
+  });
+
+  it('list returns file names only, skipping subdirectories', async () => {
+    await handleFsRequest(root, { method: 'write', path: 'releases/a.md', content: 'a' });
+    await fsp.mkdir(path.join(root, 'releases', 'sub'), { recursive: true });
+    expect(await handleFsRequest(root, { method: 'list', path: 'releases' })).toEqual(['a.md']);
+  });
+
+  it('read returns null for a missing file (preload reconstructs the error)', async () => {
+    expect(await handleFsRequest(root, { method: 'read', path: 'config.yaml' })).toBeNull();
+  });
+
+  it('stat returns null for a missing file', async () => {
+    expect(await handleFsRequest(root, { method: 'stat', path: 'config.yaml' })).toBeNull();
+  });
+
+  it('stat returns a numeric lastModified for an existing file', async () => {
+    await handleFsRequest(root, { method: 'write', path: 'config.yaml', content: 'x' });
+    const stat = (await handleFsRequest(root, {
+      method: 'stat',
+      path: 'config.yaml',
+    })) as { lastModified: number } | null;
+    expect(typeof stat?.lastModified).toBe('number');
+  });
+
+  it('throws on a path that escapes the board root', async () => {
+    await expect(
+      handleFsRequest(root, { method: 'read', path: '../escape' }),
+    ).rejects.toThrow(/Invalid path/);
+  });
+});

--- a/packages/electron/src/main/board-fs.ts
+++ b/packages/electron/src/main/board-fs.ts
@@ -1,0 +1,69 @@
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import type { FileStat } from '@boardown/core';
+import type { FsRequest } from '../bridge';
+
+// Join a renderer-supplied relative path onto the board root, rejecting absolute
+// paths and any '..' escape — a mirror of packages/web's dev-fs-plugin guard, so
+// the renderer can never reach outside the open board's .boardown/ directory.
+// Exported for unit tests: this is the sole boundary between the renderer and
+// arbitrary disk paths, so its edge cases are covered directly.
+export function resolveTarget(boardRoot: string, userPath: string): string | null {
+  const normalized = userPath.replace(/\\/g, '/');
+  if (normalized.startsWith('/') || /^[a-zA-Z]:/.test(normalized)) {
+    return null;
+  }
+  const abs = path.resolve(boardRoot, normalized);
+  const rel = path.relative(boardRoot, abs);
+  if (rel.startsWith('..') || path.isAbsolute(rel)) {
+    return null;
+  }
+  return abs;
+}
+
+function isENOENT(err: unknown): boolean {
+  return (err as NodeJS.ErrnoException).code === 'ENOENT';
+}
+
+// Run one FsAdapter operation against the board root. ENOENT is an expected,
+// handled case for callers (missing config -> onboarding, optional backlog),
+// so list -> [], stat -> null, and read -> null too: returning null instead of
+// throwing keeps Electron's IPC layer from logging a stack for every absent
+// file. The preload turns a null read back into the rejection FsAdapter.read
+// promises, so the renderer contract is unchanged.
+export async function handleFsRequest(boardRoot: string, req: FsRequest): Promise<unknown> {
+  const target = resolveTarget(boardRoot, req.path);
+  if (target === null) {
+    throw new Error(`Invalid path: ${req.path}`);
+  }
+
+  switch (req.method) {
+    case 'read':
+      try {
+        return await fsp.readFile(target, 'utf-8');
+      } catch (err) {
+        if (isENOENT(err)) return null;
+        throw err;
+      }
+    case 'write':
+      await fsp.mkdir(path.dirname(target), { recursive: true });
+      await fsp.writeFile(target, req.content ?? '', 'utf-8');
+      return undefined;
+    case 'list':
+      try {
+        const entries = await fsp.readdir(target, { withFileTypes: true });
+        return entries.filter((e) => e.isFile()).map((e) => e.name);
+      } catch (err) {
+        if (isENOENT(err)) return [];
+        throw err;
+      }
+    case 'stat':
+      try {
+        const s = await fsp.stat(target);
+        return { lastModified: s.mtimeMs } satisfies FileStat;
+      } catch (err) {
+        if (isENOENT(err)) return null;
+        throw err;
+      }
+  }
+}

--- a/packages/electron/src/main/main.ts
+++ b/packages/electron/src/main/main.ts
@@ -11,10 +11,11 @@ import {
   type IpcMainInvokeEvent,
 } from 'electron';
 import type { Theme } from '@boardown/core';
-import { IPC, type BootstrapState, type FsRequest } from '../bridge';
+import { IPC, type BootstrapState, type FsRequest, type ThemeChoice } from '../bridge';
 import { handleFsRequest } from './board-fs';
 import { buildAppMenu } from './menu';
 import { addRecent, isKnownRecent, listRecents, removeRecent } from './recent-folders';
+import { isThemeChoice, loadThemeChoice, saveThemeChoice } from './settings';
 
 // Pin the app name before anything reads app.getPath('userData') (Electron
 // caches it on first access). Otherwise dev (`electron .`) would derive it from
@@ -37,8 +38,20 @@ interface BoardContext {
 }
 const boards = new Map<number, BoardContext>();
 
-function currentTheme(): Theme {
-  return nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+// App-wide theme choice (persisted), loaded on startup. The resolved light/dark
+// value depends on it: 'system' follows the OS, 'light'/'dark' are fixed.
+let themeChoice: ThemeChoice = 'system';
+
+function effectiveTheme(): Theme {
+  if (themeChoice === 'system') return nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+  return themeChoice;
+}
+
+function broadcastTheme(): void {
+  const theme = effectiveTheme();
+  for (const window of BrowserWindow.getAllWindows()) {
+    window.webContents.send(IPC.themeChanged, theme);
+  }
 }
 
 function setBoard(window: BrowserWindow, folder: string): void {
@@ -99,7 +112,7 @@ function createWindow(initialFolder: string | null): void {
     height: 760,
     minWidth: 600,
     minHeight: 400,
-    backgroundColor: currentTheme() === 'dark' ? '#121314' : '#ffffff',
+    backgroundColor: effectiveTheme() === 'dark' ? '#121314' : '#ffffff',
     title: 'boardown',
     webPreferences: {
       preload: path.join(__dirname, 'preload.js'),
@@ -146,7 +159,8 @@ function registerIpc(): void {
   ipcMain.on(IPC.bootstrap, (event) => {
     const ctx = boards.get(event.sender.id);
     const state: BootstrapState = {
-      theme: currentTheme(),
+      theme: effectiveTheme(),
+      themeChoice,
       initialFolder: ctx?.folder ?? null,
     };
     event.returnValue = state;
@@ -183,11 +197,22 @@ function registerIpc(): void {
   });
 
   ipcMain.handle(IPC.getRecents, () => listRecents());
+
+  ipcMain.handle(IPC.setThemeChoice, async (_event: IpcMainInvokeEvent, choice: ThemeChoice) => {
+    // IPC is an untrusted, stringly-typed boundary — validate before persisting.
+    if (!isThemeChoice(choice)) return;
+    // Persist first; only update in-memory + broadcast if the write succeeded,
+    // so a failed save leaves main consistent (and the renderer reverts its UI).
+    await saveThemeChoice(choice);
+    themeChoice = choice;
+    broadcastTheme();
+  });
 }
 
 app
   .whenReady()
-  .then(() => {
+  .then(async () => {
+    themeChoice = await loadThemeChoice();
     registerIpc();
     applySecurityHeaders();
     Menu.setApplicationMenu(
@@ -198,12 +223,9 @@ app
     );
     createWindow(parseFolderArg(process.argv));
 
-    nativeTheme.on('updated', () => {
-      const theme = currentTheme();
-      for (const window of BrowserWindow.getAllWindows()) {
-        window.webContents.send(IPC.themeChanged, theme);
-      }
-    });
+    // In 'system' mode the effective theme tracks the OS; in fixed modes
+    // broadcastTheme re-sends the same value, which is a harmless no-op.
+    nativeTheme.on('updated', () => broadcastTheme());
 
     app.on('activate', () => {
       if (BrowserWindow.getAllWindows().length === 0) createWindow(null);

--- a/packages/electron/src/main/main.ts
+++ b/packages/electron/src/main/main.ts
@@ -7,6 +7,7 @@ import {
   ipcMain,
   Menu,
   nativeTheme,
+  screen,
   session,
   type IpcMainInvokeEvent,
 } from 'electron';
@@ -15,7 +16,13 @@ import { IPC, type BootstrapState, type FsRequest, type ThemeChoice } from '../b
 import { handleFsRequest } from './board-fs';
 import { buildAppMenu } from './menu';
 import { addRecent, isKnownRecent, listRecents, removeRecent } from './recent-folders';
-import { isThemeChoice, loadThemeChoice, saveThemeChoice } from './settings';
+import {
+  isThemeChoice,
+  loadSettings,
+  saveSettings,
+  type Settings,
+  type WindowBounds,
+} from './settings';
 
 // Pin the app name before anything reads app.getPath('userData') (Electron
 // caches it on first access). Otherwise dev (`electron .`) would derive it from
@@ -38,13 +45,38 @@ interface BoardContext {
 }
 const boards = new Map<number, BoardContext>();
 
-// App-wide theme choice (persisted), loaded on startup. The resolved light/dark
-// value depends on it: 'system' follows the OS, 'light'/'dark' are fixed.
-let themeChoice: ThemeChoice = 'system';
+// Persisted app settings (theme choice + window bounds), loaded on startup.
+let settings: Settings = { themeChoice: 'system' };
 
 function effectiveTheme(): Theme {
-  if (themeChoice === 'system') return nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
-  return themeChoice;
+  if (settings.themeChoice === 'system') return nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+  return settings.themeChoice;
+}
+
+// Whether saved bounds overlap a currently-connected display, so we don't
+// restore a window onto a monitor that has been unplugged.
+function boundsVisible(bounds: WindowBounds): boolean {
+  return screen.getAllDisplays().some(({ workArea }) => {
+    return (
+      bounds.x < workArea.x + workArea.width &&
+      bounds.x + bounds.width > workArea.x &&
+      bounds.y < workArea.y + workArea.height &&
+      bounds.y + bounds.height > workArea.y
+    );
+  });
+}
+
+function rememberWindow(window: BrowserWindow): void {
+  if (window.isDestroyed()) return;
+  // getNormalBounds() is the un-maximized geometry, so a maximized window
+  // restores to a sensible size (not a fake-maximized frame); the flag restores
+  // the maximized state itself.
+  settings = {
+    ...settings,
+    windowBounds: window.getNormalBounds(),
+    windowMaximized: window.isMaximized(),
+  };
+  void saveSettings(settings);
 }
 
 function broadcastTheme(): void {
@@ -107,9 +139,11 @@ function parseFolderArg(argv: string[]): string | null {
 }
 
 function createWindow(initialFolder: string | null): void {
+  const saved = settings.windowBounds;
   const window = new BrowserWindow({
-    width: 1100,
-    height: 760,
+    width: saved?.width ?? 1100,
+    height: saved?.height ?? 760,
+    ...(saved && boundsVisible(saved) ? { x: saved.x, y: saved.y } : {}),
     minWidth: 600,
     minHeight: 400,
     backgroundColor: effectiveTheme() === 'dark' ? '#121314' : '#ffffff',
@@ -127,9 +161,27 @@ function createWindow(initialFolder: string | null): void {
     setBoard(window, initialFolder);
     void addRecent(initialFolder);
   }
+
+  // Remember size/position across launches. Debounce resize/move (they fire in
+  // bursts) and also save on close; writes are atomic, so a force-quit can't
+  // corrupt the settings file.
+  let boundsTimer: ReturnType<typeof setTimeout> | undefined;
+  const scheduleBoundsSave = (): void => {
+    clearTimeout(boundsTimer);
+    boundsTimer = setTimeout(() => rememberWindow(window), 400);
+  };
+  window.on('resize', scheduleBoundsSave);
+  window.on('move', scheduleBoundsSave);
+  window.on('close', () => {
+    clearTimeout(boundsTimer);
+    rememberWindow(window);
+  });
+
   window.webContents.on('destroyed', () => {
     boards.delete(id);
   });
+
+  if (settings.windowMaximized) window.maximize();
 
   if (DEV_SERVER_URL !== undefined) {
     void window.loadURL(DEV_SERVER_URL);
@@ -160,7 +212,7 @@ function registerIpc(): void {
     const ctx = boards.get(event.sender.id);
     const state: BootstrapState = {
       theme: effectiveTheme(),
-      themeChoice,
+      themeChoice: settings.themeChoice,
       initialFolder: ctx?.folder ?? null,
     };
     event.returnValue = state;
@@ -203,8 +255,9 @@ function registerIpc(): void {
     if (!isThemeChoice(choice)) return;
     // Persist first; only update in-memory + broadcast if the write succeeded,
     // so a failed save leaves main consistent (and the renderer reverts its UI).
-    await saveThemeChoice(choice);
-    themeChoice = choice;
+    const next: Settings = { ...settings, themeChoice: choice };
+    await saveSettings(next);
+    settings = next;
     broadcastTheme();
   });
 }
@@ -212,7 +265,7 @@ function registerIpc(): void {
 app
   .whenReady()
   .then(async () => {
-    themeChoice = await loadThemeChoice();
+    settings = await loadSettings();
     registerIpc();
     applySecurityHeaders();
     Menu.setApplicationMenu(

--- a/packages/electron/src/main/main.ts
+++ b/packages/electron/src/main/main.ts
@@ -68,13 +68,15 @@ function boundsVisible(bounds: WindowBounds): boolean {
 
 function rememberWindow(window: BrowserWindow): void {
   if (window.isDestroyed()) return;
-  // getNormalBounds() is the un-maximized geometry, so a maximized window
-  // restores to a sensible size (not a fake-maximized frame); the flag restores
-  // the maximized state itself.
+  const maximized = window.isMaximized();
+  // Capture geometry only in the normal state — a maximized or full-screen frame
+  // (including the macOS zoom) isn't a size to restore to, so the kept bounds
+  // stay the real window size and carry the screen position. windowMaximized
+  // restores the maximized state; full screen is intentionally not restored.
   settings = {
     ...settings,
-    windowBounds: window.getNormalBounds(),
-    windowMaximized: window.isMaximized(),
+    ...(maximized || window.isFullScreen() ? {} : { windowBounds: window.getBounds() }),
+    windowMaximized: maximized,
   };
   void saveSettings(settings);
 }
@@ -92,14 +94,21 @@ function setBoard(window: BrowserWindow, folder: string): void {
 
 async function openBoard(window: BrowserWindow, folder: string): Promise<void> {
   setBoard(window, folder);
+  // Remember it as the last-open project so it reopens on next launch.
+  settings = { ...settings, lastFolder: folder };
   await addRecent(folder);
+  void saveSettings(settings);
   window.webContents.send(IPC.boardOpened, folder);
 }
 
 // Drop the window's board and send it back to the welcome screen. The board
-// stays in recents, so reopening it is one click away.
+// stays in recents, so reopening it is one click away — but closing is
+// deliberate, so don't auto-reopen it on next launch.
 function closeBoard(window: BrowserWindow): void {
   boards.delete(window.webContents.id);
+  const { lastFolder, ...rest } = settings;
+  settings = rest;
+  void saveSettings(settings);
   window.webContents.send(IPC.boardClosed);
 }
 
@@ -138,6 +147,12 @@ function parseFolderArg(argv: string[]): string | null {
   return null;
 }
 
+// The project to reopen on launch when no folder is passed on the CLI: the last
+// one that was open, if it still exists on disk.
+function lastOpenedFolder(): string | null {
+  return settings.lastFolder && isDirectory(settings.lastFolder) ? settings.lastFolder : null;
+}
+
 function createWindow(initialFolder: string | null): void {
   const saved = settings.windowBounds;
   const window = new BrowserWindow({
@@ -159,7 +174,9 @@ function createWindow(initialFolder: string | null): void {
   const id = window.webContents.id;
   if (initialFolder !== null) {
     setBoard(window, initialFolder);
+    settings = { ...settings, lastFolder: initialFolder };
     void addRecent(initialFolder);
+    void saveSettings(settings);
   }
 
   // Remember size/position across launches. Debounce resize/move (they fire in
@@ -241,7 +258,12 @@ function registerIpc(): void {
     const ctx = boards.get(event.sender.id);
     if (!ctx) return;
     boards.delete(event.sender.id);
+    if (settings.lastFolder === ctx.folder) {
+      const { lastFolder, ...rest } = settings;
+      settings = rest;
+    }
     await removeRecent(ctx.folder);
+    void saveSettings(settings);
   });
 
   ipcMain.handle(IPC.removeRecent, async (_event: IpcMainInvokeEvent, folder: string) => {
@@ -274,14 +296,14 @@ app
         closeBoard: (window) => closeBoard(window),
       }),
     );
-    createWindow(parseFolderArg(process.argv));
+    createWindow(parseFolderArg(process.argv) ?? lastOpenedFolder());
 
     // In 'system' mode the effective theme tracks the OS; in fixed modes
     // broadcastTheme re-sends the same value, which is a harmless no-op.
     nativeTheme.on('updated', () => broadcastTheme());
 
     app.on('activate', () => {
-      if (BrowserWindow.getAllWindows().length === 0) createWindow(null);
+      if (BrowserWindow.getAllWindows().length === 0) createWindow(lastOpenedFolder());
     });
   })
   .catch((err: unknown) => {

--- a/packages/electron/src/main/main.ts
+++ b/packages/electron/src/main/main.ts
@@ -16,6 +16,13 @@ import { handleFsRequest } from './board-fs';
 import { buildAppMenu } from './menu';
 import { addRecent, isKnownRecent, listRecents, removeRecent } from './recent-folders';
 
+// Pin the app name before anything reads app.getPath('userData') (Electron
+// caches it on first access). Otherwise dev (`electron .`) would derive it from
+// package.json (`@boardown/electron`) while the packaged app uses productName
+// ('boardown'), so the two would keep their recent-folders list in different
+// directories. Setting it here makes both use the same `boardown` userData dir.
+app.setName('boardown');
+
 // Set by the dev script; when present the renderer is served from Vite with HMR
 // instead of the packaged files, and we skip the production CSP (Vite needs its
 // own for HMR).

--- a/packages/electron/src/main/main.ts
+++ b/packages/electron/src/main/main.ts
@@ -1,0 +1,212 @@
+import { statSync } from 'node:fs';
+import path from 'node:path';
+import {
+  app,
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  Menu,
+  nativeTheme,
+  session,
+  type IpcMainInvokeEvent,
+} from 'electron';
+import type { Theme } from '@boardown/core';
+import { IPC, type BootstrapState, type FsRequest } from '../bridge';
+import { handleFsRequest } from './board-fs';
+import { buildAppMenu } from './menu';
+import { addRecent, isKnownRecent, listRecents, removeRecent } from './recent-folders';
+
+// Set by the dev script; when present the renderer is served from Vite with HMR
+// instead of the packaged files, and we skip the production CSP (Vite needs its
+// own for HMR).
+const DEV_SERVER_URL = process.env.BOARDOWN_RENDERER_URL;
+const BOARD_DIR = '.boardown';
+
+// Per-window board context, keyed by webContents id: the project folder the user
+// opened and the .boardown root every fs request for that window resolves to.
+interface BoardContext {
+  folder: string;
+  boardRoot: string;
+}
+const boards = new Map<number, BoardContext>();
+
+function currentTheme(): Theme {
+  return nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
+}
+
+function setBoard(window: BrowserWindow, folder: string): void {
+  boards.set(window.webContents.id, { folder, boardRoot: path.join(folder, BOARD_DIR) });
+}
+
+async function openBoard(window: BrowserWindow, folder: string): Promise<void> {
+  setBoard(window, folder);
+  await addRecent(folder);
+  window.webContents.send(IPC.boardOpened, folder);
+}
+
+// Drop the window's board and send it back to the welcome screen. The board
+// stays in recents, so reopening it is one click away.
+function closeBoard(window: BrowserWindow): void {
+  boards.delete(window.webContents.id);
+  window.webContents.send(IPC.boardClosed);
+}
+
+async function showOpenDialog(window: BrowserWindow): Promise<void> {
+  const result = await dialog.showOpenDialog(window, {
+    title: 'Open Board Folder',
+    properties: ['openDirectory', 'createDirectory'],
+  });
+  const folder = result.filePaths[0];
+  if (result.canceled || folder === undefined) return;
+  await openBoard(window, folder);
+}
+
+function isDirectory(target: string): boolean {
+  try {
+    return statSync(target).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+// CLI args minus Electron's own: in dev (`electron <appDir> …`) argv[1] is the
+// app directory, while in a packaged app argv[1] is already the first real arg.
+function cliArgs(argv: string[]): string[] {
+  return process.defaultApp ? argv.slice(2) : argv.slice(1);
+}
+
+// First CLI argument that resolves to an existing directory, so both the
+// packaged form (`boardown <folder>`) and `pnpm dev -- <folder>` open it on boot.
+function parseFolderArg(argv: string[]): string | null {
+  for (const arg of cliArgs(argv)) {
+    if (arg.startsWith('-')) continue;
+    const resolved = path.resolve(arg);
+    if (isDirectory(resolved)) return resolved;
+  }
+  return null;
+}
+
+function createWindow(initialFolder: string | null): void {
+  const window = new BrowserWindow({
+    width: 1100,
+    height: 760,
+    minWidth: 600,
+    minHeight: 400,
+    backgroundColor: currentTheme() === 'dark' ? '#121314' : '#ffffff',
+    title: 'boardown',
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+    },
+  });
+
+  const id = window.webContents.id;
+  if (initialFolder !== null) {
+    setBoard(window, initialFolder);
+    void addRecent(initialFolder);
+  }
+  window.webContents.on('destroyed', () => {
+    boards.delete(id);
+  });
+
+  if (DEV_SERVER_URL !== undefined) {
+    void window.loadURL(DEV_SERVER_URL);
+  } else {
+    void window.loadFile(path.join(__dirname, 'renderer', 'index.html'));
+  }
+}
+
+// Lock the renderer down to its own bundled assets in production. Skipped under
+// the Vite dev server, which serves inline scripts and a websocket for HMR.
+function applySecurityHeaders(): void {
+  if (DEV_SERVER_URL !== undefined) return;
+  session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
+    callback({
+      responseHeaders: {
+        ...details.responseHeaders,
+        'Content-Security-Policy': [
+          "default-src 'none'; img-src 'self' data:; font-src 'self'; " +
+            "style-src 'self' 'unsafe-inline'; script-src 'self'",
+        ],
+      },
+    });
+  });
+}
+
+function registerIpc(): void {
+  ipcMain.on(IPC.bootstrap, (event) => {
+    const ctx = boards.get(event.sender.id);
+    const state: BootstrapState = {
+      theme: currentTheme(),
+      initialFolder: ctx?.folder ?? null,
+    };
+    event.returnValue = state;
+  });
+
+  ipcMain.handle(IPC.fs, async (event: IpcMainInvokeEvent, req: FsRequest) => {
+    const ctx = boards.get(event.sender.id);
+    if (!ctx) throw new Error('No board is open for this window');
+    return handleFsRequest(ctx.boardRoot, req);
+  });
+
+  ipcMain.handle(IPC.pickFolder, async (event: IpcMainInvokeEvent) => {
+    const window = BrowserWindow.fromWebContents(event.sender);
+    if (window) await showOpenDialog(window);
+  });
+
+  ipcMain.handle(IPC.openRecent, async (event: IpcMainInvokeEvent, folder: string) => {
+    const window = BrowserWindow.fromWebContents(event.sender);
+    if (!window) return;
+    // Only honor folders we actually offered; never let the renderer point the
+    // board root at an arbitrary path without going through the native dialog.
+    if (await isKnownRecent(folder)) await openBoard(window, folder);
+  });
+
+  ipcMain.handle(IPC.cancelBoard, async (event: IpcMainInvokeEvent) => {
+    const ctx = boards.get(event.sender.id);
+    if (!ctx) return;
+    boards.delete(event.sender.id);
+    await removeRecent(ctx.folder);
+  });
+
+  ipcMain.handle(IPC.removeRecent, async (_event: IpcMainInvokeEvent, folder: string) => {
+    await removeRecent(folder);
+  });
+
+  ipcMain.handle(IPC.getRecents, () => listRecents());
+}
+
+app
+  .whenReady()
+  .then(() => {
+    registerIpc();
+    applySecurityHeaders();
+    Menu.setApplicationMenu(
+      buildAppMenu({
+        openFolder: (window) => void showOpenDialog(window),
+        closeBoard: (window) => closeBoard(window),
+      }),
+    );
+    createWindow(parseFolderArg(process.argv));
+
+    nativeTheme.on('updated', () => {
+      const theme = currentTheme();
+      for (const window of BrowserWindow.getAllWindows()) {
+        window.webContents.send(IPC.themeChanged, theme);
+      }
+    });
+
+    app.on('activate', () => {
+      if (BrowserWindow.getAllWindows().length === 0) createWindow(null);
+    });
+  })
+  .catch((err: unknown) => {
+    console.error(err);
+    app.quit();
+  });
+
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') app.quit();
+});

--- a/packages/electron/src/main/menu.ts
+++ b/packages/electron/src/main/menu.ts
@@ -5,10 +5,10 @@ interface MenuActions {
   closeBoard: (window: BrowserWindow) => void;
 }
 
-// Native application menu. Built-in roles cover Edit (so copy/paste/undo work in
-// the board's text inputs), View (reload, devtools, zoom) and Window; the custom
-// File items drive the board picker (Open Folder…) and return to the welcome
-// screen (Close Board).
+// Native application menu, kept lean. Edit/Window use built-in roles (so
+// copy/paste/undo work in the board's inputs); File drives the board picker and
+// Close Board; View is trimmed to zoom / full screen / dev tools — the board has
+// its own Reload, so the menu's Reload / Force Reload are left out.
 export function buildAppMenu(actions: MenuActions): Menu {
   const isMac = process.platform === 'darwin';
 
@@ -36,7 +36,17 @@ export function buildAppMenu(actions: MenuActions): Menu {
       ],
     },
     { role: 'editMenu' },
-    { role: 'viewMenu' },
+    {
+      label: 'View',
+      submenu: [
+        { role: 'resetZoom' },
+        { role: 'zoomIn' },
+        { role: 'zoomOut' },
+        { type: 'separator' },
+        { role: 'togglefullscreen' },
+        { role: 'toggleDevTools' },
+      ],
+    },
     { role: 'windowMenu' },
   ];
 

--- a/packages/electron/src/main/menu.ts
+++ b/packages/electron/src/main/menu.ts
@@ -1,0 +1,44 @@
+import { Menu, type BrowserWindow, type MenuItemConstructorOptions } from 'electron';
+
+interface MenuActions {
+  openFolder: (window: BrowserWindow) => void;
+  closeBoard: (window: BrowserWindow) => void;
+}
+
+// Native application menu. Built-in roles cover Edit (so copy/paste/undo work in
+// the board's text inputs), View (reload, devtools, zoom) and Window; the custom
+// File items drive the board picker (Open Folder…) and return to the welcome
+// screen (Close Board).
+export function buildAppMenu(actions: MenuActions): Menu {
+  const isMac = process.platform === 'darwin';
+
+  const template: MenuItemConstructorOptions[] = [
+    ...(isMac ? [{ role: 'appMenu' as const }] : []),
+    {
+      label: 'File',
+      submenu: [
+        {
+          label: 'Open Folder…',
+          accelerator: 'CmdOrCtrl+O',
+          click: (_item, window) => {
+            if (window) actions.openFolder(window as BrowserWindow);
+          },
+        },
+        {
+          label: 'Close Board',
+          accelerator: 'CmdOrCtrl+Shift+W',
+          click: (_item, window) => {
+            if (window) actions.closeBoard(window as BrowserWindow);
+          },
+        },
+        { type: 'separator' },
+        isMac ? { role: 'close' } : { role: 'quit' },
+      ],
+    },
+    { role: 'editMenu' },
+    { role: 'viewMenu' },
+    { role: 'windowMenu' },
+  ];
+
+  return Menu.buildFromTemplate(template);
+}

--- a/packages/electron/src/main/preload.ts
+++ b/packages/electron/src/main/preload.ts
@@ -14,6 +14,7 @@ const fsCall = (req: FsRequest): Promise<unknown> => ipcRenderer.invoke(IPC.fs, 
 
 const bridge: BoardownBridge = {
   theme: bootstrap.theme,
+  themeChoice: bootstrap.themeChoice,
   initialFolder: bootstrap.initialFolder,
   fs: {
     read: async (filePath) => {
@@ -34,6 +35,7 @@ const bridge: BoardownBridge = {
   cancelBoard: () => ipcRenderer.invoke(IPC.cancelBoard) as Promise<void>,
   removeRecent: (folder) => ipcRenderer.invoke(IPC.removeRecent, folder) as Promise<void>,
   getRecents: () => ipcRenderer.invoke(IPC.getRecents) as Promise<ProjectEntry[]>,
+  setThemeChoice: (choice) => ipcRenderer.invoke(IPC.setThemeChoice, choice) as Promise<void>,
   onBoardOpened: (listener) => {
     const handler = (_event: IpcRendererEvent, folder: string): void => listener(folder);
     ipcRenderer.on(IPC.boardOpened, handler);

--- a/packages/electron/src/main/preload.ts
+++ b/packages/electron/src/main/preload.ts
@@ -1,0 +1,54 @@
+import { contextBridge, ipcRenderer, type IpcRendererEvent } from 'electron';
+import type { FileStat, Theme } from '@boardown/core';
+import {
+  IPC,
+  type BoardownBridge,
+  type BootstrapState,
+  type FsRequest,
+  type ProjectEntry,
+} from '../bridge';
+
+const bootstrap = ipcRenderer.sendSync(IPC.bootstrap) as BootstrapState;
+
+const fsCall = (req: FsRequest): Promise<unknown> => ipcRenderer.invoke(IPC.fs, req);
+
+const bridge: BoardownBridge = {
+  theme: bootstrap.theme,
+  initialFolder: bootstrap.initialFolder,
+  fs: {
+    read: async (filePath) => {
+      // Host returns null for a missing file (no IPC error log); restore the
+      // rejection FsAdapter.read promises so the loader's try/catch still works.
+      const result = await fsCall({ method: 'read', path: filePath });
+      if (result === null) throw new Error(`ENOENT: ${filePath}`);
+      return result as string;
+    },
+    write: async (filePath, content) => {
+      await fsCall({ method: 'write', path: filePath, content });
+    },
+    list: (dir) => fsCall({ method: 'list', path: dir }) as Promise<string[]>,
+    stat: (filePath) => fsCall({ method: 'stat', path: filePath }) as Promise<FileStat | null>,
+  },
+  pickFolder: () => ipcRenderer.invoke(IPC.pickFolder) as Promise<void>,
+  openRecent: (folder) => ipcRenderer.invoke(IPC.openRecent, folder) as Promise<void>,
+  cancelBoard: () => ipcRenderer.invoke(IPC.cancelBoard) as Promise<void>,
+  removeRecent: (folder) => ipcRenderer.invoke(IPC.removeRecent, folder) as Promise<void>,
+  getRecents: () => ipcRenderer.invoke(IPC.getRecents) as Promise<ProjectEntry[]>,
+  onBoardOpened: (listener) => {
+    const handler = (_event: IpcRendererEvent, folder: string): void => listener(folder);
+    ipcRenderer.on(IPC.boardOpened, handler);
+    return () => ipcRenderer.removeListener(IPC.boardOpened, handler);
+  },
+  onBoardClosed: (listener) => {
+    const handler = (): void => listener();
+    ipcRenderer.on(IPC.boardClosed, handler);
+    return () => ipcRenderer.removeListener(IPC.boardClosed, handler);
+  },
+  onThemeChange: (listener) => {
+    const handler = (_event: IpcRendererEvent, theme: Theme): void => listener(theme);
+    ipcRenderer.on(IPC.themeChanged, handler);
+    return () => ipcRenderer.removeListener(IPC.themeChanged, handler);
+  },
+};
+
+contextBridge.exposeInMainWorld('boardown', bridge);

--- a/packages/electron/src/main/recent-folders.test.ts
+++ b/packages/electron/src/main/recent-folders.test.ts
@@ -1,0 +1,98 @@
+import { promises as fsp } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// recent-folders stores its JSON under app.getPath('userData'); there is no
+// Electron runtime in a unit test, so point that at a temp dir per test.
+const { state } = vi.hoisted(() => ({ state: { userData: '' } }));
+vi.mock('electron', () => ({
+  app: { getPath: () => state.userData },
+}));
+
+import { addRecent, isKnownRecent, listRecents, removeRecent } from './recent-folders';
+
+let created: string[] = [];
+
+const makeProject = async (label: string, withBoard = false): Promise<string> => {
+  const dir = await fsp.mkdtemp(path.join(os.tmpdir(), `boardown-proj-${label}-`));
+  created.push(dir);
+  if (withBoard) {
+    await fsp.mkdir(path.join(dir, '.boardown'), { recursive: true });
+    await fsp.writeFile(path.join(dir, '.boardown', 'config.yaml'), 'idPrefix: AA\nnextId: 1\n');
+  }
+  return dir;
+};
+
+describe('recent-folders', () => {
+  beforeEach(async () => {
+    state.userData = await fsp.mkdtemp(path.join(os.tmpdir(), 'boardown-recents-'));
+    created = [];
+  });
+
+  afterEach(async () => {
+    for (const dir of [...created, state.userData]) {
+      await fsp.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('adds entries most-recent-first', async () => {
+    const a = await makeProject('a');
+    const b = await makeProject('b');
+    await addRecent(a);
+    await addRecent(b);
+    expect((await listRecents()).map((e) => e.folder)).toEqual([b, a]);
+  });
+
+  it('dedups by folder and bumps the repeat to the top', async () => {
+    const a = await makeProject('a');
+    const b = await makeProject('b');
+    await addRecent(a);
+    await addRecent(b);
+    await addRecent(a);
+    const list = await listRecents();
+    expect(list.map((e) => e.folder)).toEqual([a, b]);
+  });
+
+  it('caps the list at ten entries', async () => {
+    for (let i = 0; i < 12; i += 1) {
+      await addRecent(await makeProject(`p${i}`));
+    }
+    expect((await listRecents()).length).toBe(10);
+  });
+
+  it('removeRecent drops one entry, keeps the rest', async () => {
+    const a = await makeProject('a');
+    const b = await makeProject('b');
+    await addRecent(a);
+    await addRecent(b);
+    await removeRecent(a);
+    expect((await listRecents()).map((e) => e.folder)).toEqual([b]);
+  });
+
+  it('isKnownRecent checks membership without pruning', async () => {
+    const a = await makeProject('a');
+    await addRecent(a);
+    expect(await isKnownRecent(a)).toBe(true);
+    expect(await isKnownRecent('/definitely/not/here')).toBe(false);
+  });
+
+  it('listRecents prunes folders that no longer exist', async () => {
+    const a = await makeProject('a');
+    const b = await makeProject('b');
+    await addRecent(a);
+    await addRecent(b);
+    await fsp.rm(b, { recursive: true, force: true });
+    expect((await listRecents()).map((e) => e.folder)).toEqual([a]);
+  });
+
+  it('flags hasBoard from the presence of .boardown/config.yaml', async () => {
+    const withBoard = await makeProject('wb', true);
+    const without = await makeProject('wo', false);
+    await addRecent(withBoard);
+    await addRecent(without);
+    const list = await listRecents();
+    expect(list.find((e) => e.folder === withBoard)?.hasBoard).toBe(true);
+    expect(list.find((e) => e.folder === without)?.hasBoard).toBe(false);
+  });
+});

--- a/packages/electron/src/main/recent-folders.ts
+++ b/packages/electron/src/main/recent-folders.ts
@@ -1,0 +1,80 @@
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import { app } from 'electron';
+import type { ProjectEntry, RecentEntry } from '../bridge';
+
+const MAX_RECENTS = 10;
+
+function storePath(): string {
+  return path.join(app.getPath('userData'), 'recent-folders.json');
+}
+
+function isRecentEntry(value: unknown): value is RecentEntry {
+  if (typeof value !== 'object' || value === null) return false;
+  const entry = value as Record<string, unknown>;
+  return (
+    typeof entry.folder === 'string' &&
+    typeof entry.name === 'string' &&
+    typeof entry.lastOpened === 'number'
+  );
+}
+
+async function loadRaw(): Promise<RecentEntry[]> {
+  try {
+    const text = await fsp.readFile(storePath(), 'utf-8');
+    const parsed: unknown = JSON.parse(text);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(isRecentEntry);
+  } catch {
+    return [];
+  }
+}
+
+async function save(entries: RecentEntry[]): Promise<void> {
+  await fsp.mkdir(path.dirname(storePath()), { recursive: true });
+  await fsp.writeFile(storePath(), JSON.stringify(entries, null, 2), 'utf-8');
+}
+
+export async function addRecent(folder: string): Promise<void> {
+  const entries = (await loadRaw()).filter((e) => e.folder !== folder);
+  entries.unshift({ folder, name: path.basename(folder), lastOpened: Date.now() });
+  await save(entries.slice(0, MAX_RECENTS));
+}
+
+// Forget a folder — used when onboarding is cancelled, so an abandoned open
+// doesn't linger in the sidebar.
+export async function removeRecent(folder: string): Promise<void> {
+  await save((await loadRaw()).filter((entry) => entry.folder !== folder));
+}
+
+// Whether a folder is among the persisted recents — the allowlist check for
+// openRecent. Uses the raw list (no stat sweep): existence pruning is a display
+// concern, not a security one.
+export async function isKnownRecent(folder: string): Promise<boolean> {
+  return (await loadRaw()).some((entry) => entry.folder === folder);
+}
+
+// Prune entries whose folder no longer exists, and flag whether each still has
+// a board (config.yaml) or needs onboarding. Stat in parallel so one stale entry
+// on a slow volume can't stall the list. Two cheap stats per project, no board
+// loading — the sidebar shows status without reading every project's tasks.
+export async function listRecents(): Promise<ProjectEntry[]> {
+  const entries = await loadRaw();
+  const checked = await Promise.all(
+    entries.map(async (entry): Promise<ProjectEntry | null> => {
+      try {
+        if (!(await fsp.stat(entry.folder)).isDirectory()) return null;
+      } catch {
+        return null;
+      }
+      let hasBoard = false;
+      try {
+        hasBoard = (await fsp.stat(path.join(entry.folder, '.boardown', 'config.yaml'))).isFile();
+      } catch {
+        hasBoard = false;
+      }
+      return { ...entry, hasBoard };
+    }),
+  );
+  return checked.filter((entry): entry is ProjectEntry => entry !== null);
+}

--- a/packages/electron/src/main/settings.test.ts
+++ b/packages/electron/src/main/settings.test.ts
@@ -1,0 +1,48 @@
+import { promises as fsp } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// settings.json lives under app.getPath('userData'); no Electron runtime in a
+// unit test, so point it at a temp dir per test.
+const { state } = vi.hoisted(() => ({ state: { userData: '' } }));
+vi.mock('electron', () => ({
+  app: { getPath: () => state.userData },
+}));
+
+import { loadThemeChoice, saveThemeChoice } from './settings';
+
+describe('settings — theme choice', () => {
+  beforeEach(async () => {
+    state.userData = await fsp.mkdtemp(path.join(os.tmpdir(), 'boardown-settings-'));
+  });
+
+  afterEach(async () => {
+    await fsp.rm(state.userData, { recursive: true, force: true });
+  });
+
+  it('defaults to system when there is no file', async () => {
+    expect(await loadThemeChoice()).toBe('system');
+  });
+
+  it('round-trips a saved choice', async () => {
+    await saveThemeChoice('dark');
+    expect(await loadThemeChoice()).toBe('dark');
+    await saveThemeChoice('light');
+    expect(await loadThemeChoice()).toBe('light');
+  });
+
+  it('falls back to system on an unknown stored value', async () => {
+    await fsp.writeFile(
+      path.join(state.userData, 'settings.json'),
+      JSON.stringify({ themeChoice: 'neon' }),
+      'utf-8',
+    );
+    expect(await loadThemeChoice()).toBe('system');
+  });
+
+  it('falls back to system on malformed JSON', async () => {
+    await fsp.writeFile(path.join(state.userData, 'settings.json'), '{ not json', 'utf-8');
+    expect(await loadThemeChoice()).toBe('system');
+  });
+});

--- a/packages/electron/src/main/settings.test.ts
+++ b/packages/electron/src/main/settings.test.ts
@@ -10,9 +10,9 @@ vi.mock('electron', () => ({
   app: { getPath: () => state.userData },
 }));
 
-import { loadThemeChoice, saveThemeChoice } from './settings';
+import { loadSettings, saveSettings } from './settings';
 
-describe('settings — theme choice', () => {
+describe('settings', () => {
   beforeEach(async () => {
     state.userData = await fsp.mkdtemp(path.join(os.tmpdir(), 'boardown-settings-'));
   });
@@ -21,28 +21,45 @@ describe('settings — theme choice', () => {
     await fsp.rm(state.userData, { recursive: true, force: true });
   });
 
-  it('defaults to system when there is no file', async () => {
-    expect(await loadThemeChoice()).toBe('system');
+  it('defaults to system theme and no bounds when there is no file', async () => {
+    expect(await loadSettings()).toEqual({ themeChoice: 'system' });
   });
 
-  it('round-trips a saved choice', async () => {
-    await saveThemeChoice('dark');
-    expect(await loadThemeChoice()).toBe('dark');
-    await saveThemeChoice('light');
-    expect(await loadThemeChoice()).toBe('light');
+  it('round-trips theme choice and window bounds', async () => {
+    const settings = {
+      themeChoice: 'dark' as const,
+      windowBounds: { x: 10, y: 20, width: 800, height: 600 },
+      windowMaximized: true,
+    };
+    await saveSettings(settings);
+    expect(await loadSettings()).toEqual(settings);
   });
 
-  it('falls back to system on an unknown stored value', async () => {
+  it('falls back to system on an unknown theme choice', async () => {
     await fsp.writeFile(
       path.join(state.userData, 'settings.json'),
       JSON.stringify({ themeChoice: 'neon' }),
       'utf-8',
     );
-    expect(await loadThemeChoice()).toBe('system');
+    expect((await loadSettings()).themeChoice).toBe('system');
   });
 
-  it('falls back to system on malformed JSON', async () => {
+  it('drops invalid window bounds', async () => {
+    await fsp.writeFile(
+      path.join(state.userData, 'settings.json'),
+      JSON.stringify({ themeChoice: 'light', windowBounds: { x: 0, y: 0, width: 0, height: -5 } }),
+      'utf-8',
+    );
+    expect(await loadSettings()).toEqual({ themeChoice: 'light' });
+  });
+
+  it('falls back to defaults on malformed JSON', async () => {
     await fsp.writeFile(path.join(state.userData, 'settings.json'), '{ not json', 'utf-8');
-    expect(await loadThemeChoice()).toBe('system');
+    expect(await loadSettings()).toEqual({ themeChoice: 'system' });
+  });
+
+  it('leaves no temp file behind after an atomic save', async () => {
+    await saveSettings({ themeChoice: 'dark' });
+    expect(await fsp.readdir(state.userData)).toEqual(['settings.json']);
   });
 });

--- a/packages/electron/src/main/settings.test.ts
+++ b/packages/electron/src/main/settings.test.ts
@@ -30,6 +30,7 @@ describe('settings', () => {
       themeChoice: 'dark' as const,
       windowBounds: { x: 10, y: 20, width: 800, height: 600 },
       windowMaximized: true,
+      lastFolder: '/Users/me/project',
     };
     await saveSettings(settings);
     expect(await loadSettings()).toEqual(settings);

--- a/packages/electron/src/main/settings.ts
+++ b/packages/electron/src/main/settings.ts
@@ -3,6 +3,19 @@ import path from 'node:path';
 import { app } from 'electron';
 import type { ThemeChoice } from '../bridge';
 
+export interface WindowBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface Settings {
+  themeChoice: ThemeChoice;
+  windowBounds?: WindowBounds;
+  windowMaximized?: boolean;
+}
+
 const CHOICES: readonly ThemeChoice[] = ['system', 'light', 'dark'];
 
 export function isThemeChoice(value: unknown): value is ThemeChoice {
@@ -13,17 +26,56 @@ function storePath(): string {
   return path.join(app.getPath('userData'), 'settings.json');
 }
 
-export async function loadThemeChoice(): Promise<ThemeChoice> {
+function parseBounds(value: unknown): WindowBounds | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const { x, y, width, height } = value as Record<string, unknown>;
+  if (
+    typeof x !== 'number' ||
+    typeof y !== 'number' ||
+    typeof width !== 'number' ||
+    typeof height !== 'number' ||
+    !Number.isFinite(x) ||
+    !Number.isFinite(y) ||
+    !Number.isFinite(width) ||
+    !Number.isFinite(height) ||
+    width <= 0 ||
+    height <= 0
+  ) {
+    return undefined;
+  }
+  return { x, y, width, height };
+}
+
+export async function loadSettings(): Promise<Settings> {
   try {
-    const parsed: unknown = JSON.parse(await fsp.readFile(storePath(), 'utf-8'));
-    const choice = (parsed as { themeChoice?: unknown }).themeChoice;
-    return isThemeChoice(choice) ? choice : 'system';
+    const raw: unknown = JSON.parse(await fsp.readFile(storePath(), 'utf-8'));
+    const obj = (typeof raw === 'object' && raw !== null ? raw : {}) as Record<string, unknown>;
+    const bounds = parseBounds(obj.windowBounds);
+    return {
+      themeChoice: isThemeChoice(obj.themeChoice) ? obj.themeChoice : 'system',
+      ...(bounds ? { windowBounds: bounds } : {}),
+      ...(obj.windowMaximized === true ? { windowMaximized: true } : {}),
+    };
   } catch {
-    return 'system';
+    return { themeChoice: 'system' };
   }
 }
 
-export async function saveThemeChoice(choice: ThemeChoice): Promise<void> {
-  await fsp.mkdir(path.dirname(storePath()), { recursive: true });
-  await fsp.writeFile(storePath(), `${JSON.stringify({ themeChoice: choice }, null, 2)}\n`, 'utf-8');
+let writeQueue: Promise<void> = Promise.resolve();
+
+// Atomic write (temp file + rename) so a force-quit mid-write can't truncate
+// settings.json — the rename either fully replaces the file or never happens, so
+// the on-disk file is always complete. Writes are serialised through a queue so
+// a theme change and a window-bounds save can't interleave into the temp file
+// (and the single temp file is overwritten next save, never accumulating).
+export function saveSettings(settings: Settings): Promise<void> {
+  const run = async (): Promise<void> => {
+    const target = storePath();
+    const tmp = `${target}.tmp`;
+    await fsp.mkdir(path.dirname(target), { recursive: true });
+    await fsp.writeFile(tmp, `${JSON.stringify(settings, null, 2)}\n`, 'utf-8');
+    await fsp.rename(tmp, target);
+  };
+  writeQueue = writeQueue.then(run, run);
+  return writeQueue;
 }

--- a/packages/electron/src/main/settings.ts
+++ b/packages/electron/src/main/settings.ts
@@ -1,0 +1,29 @@
+import { promises as fsp } from 'node:fs';
+import path from 'node:path';
+import { app } from 'electron';
+import type { ThemeChoice } from '../bridge';
+
+const CHOICES: readonly ThemeChoice[] = ['system', 'light', 'dark'];
+
+export function isThemeChoice(value: unknown): value is ThemeChoice {
+  return CHOICES.includes(value as ThemeChoice);
+}
+
+function storePath(): string {
+  return path.join(app.getPath('userData'), 'settings.json');
+}
+
+export async function loadThemeChoice(): Promise<ThemeChoice> {
+  try {
+    const parsed: unknown = JSON.parse(await fsp.readFile(storePath(), 'utf-8'));
+    const choice = (parsed as { themeChoice?: unknown }).themeChoice;
+    return isThemeChoice(choice) ? choice : 'system';
+  } catch {
+    return 'system';
+  }
+}
+
+export async function saveThemeChoice(choice: ThemeChoice): Promise<void> {
+  await fsp.mkdir(path.dirname(storePath()), { recursive: true });
+  await fsp.writeFile(storePath(), `${JSON.stringify({ themeChoice: choice }, null, 2)}\n`, 'utf-8');
+}

--- a/packages/electron/src/main/settings.ts
+++ b/packages/electron/src/main/settings.ts
@@ -14,6 +14,8 @@ export interface Settings {
   themeChoice: ThemeChoice;
   windowBounds?: WindowBounds;
   windowMaximized?: boolean;
+  // The project folder open when the app last closed, reopened on next launch.
+  lastFolder?: string;
 }
 
 const CHOICES: readonly ThemeChoice[] = ['system', 'light', 'dark'];
@@ -55,6 +57,7 @@ export async function loadSettings(): Promise<Settings> {
       themeChoice: isThemeChoice(obj.themeChoice) ? obj.themeChoice : 'system',
       ...(bounds ? { windowBounds: bounds } : {}),
       ...(obj.windowMaximized === true ? { windowMaximized: true } : {}),
+      ...(typeof obj.lastFolder === 'string' ? { lastFolder: obj.lastFolder } : {}),
     };
   } catch {
     return { themeChoice: 'system' };

--- a/packages/electron/src/renderer/Root.module.css
+++ b/packages/electron/src/renderer/Root.module.css
@@ -12,6 +12,22 @@
   overflow: hidden;
 }
 
+/* Drag handle straddling the sidebar's right edge; negative margin keeps it from
+ * adding a gap between the sidebar and the board. */
+.resizer {
+  position: relative;
+  z-index: 1;
+  flex-shrink: 0;
+  width: 6px;
+  margin-left: -6px;
+  cursor: col-resize;
+  background: transparent;
+}
+
+.resizer:hover {
+  background: var(--shell-border);
+}
+
 .empty {
   display: flex;
   flex-direction: column;

--- a/packages/electron/src/renderer/Root.module.css
+++ b/packages/electron/src/renderer/Root.module.css
@@ -1,0 +1,55 @@
+.layout {
+  display: flex;
+  height: 100vh;
+}
+
+/* App (@boardown/ui) is height:100vh; clip here so it fills the main area
+ * exactly instead of overflowing the flex row. */
+.main {
+  flex: 1;
+  min-width: 0;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  height: 100%;
+  padding: 32px;
+  text-align: center;
+  background: var(--shell-bg);
+}
+
+.emptyTitle {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--shell-text);
+}
+
+.emptyHint {
+  margin: 0;
+  max-width: 360px;
+  font-size: 14px;
+  color: var(--shell-text-muted);
+}
+
+.emptyButton {
+  margin-top: 4px;
+  padding: 10px 16px;
+  border: none;
+  border-radius: 8px;
+  background: var(--shell-accent);
+  color: var(--shell-accent-fg);
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.emptyButton:hover {
+  opacity: 0.92;
+}

--- a/packages/electron/src/renderer/Root.tsx
+++ b/packages/electron/src/renderer/Root.tsx
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+} from 'react';
 import { App } from '@boardown/ui';
 import type { ProjectEntry, ThemeChoice } from '../bridge';
 import { Sidebar } from './Sidebar';
@@ -6,6 +12,21 @@ import { folderName, suggestIdPrefix } from './project-name';
 import styles from './Root.module.css';
 
 const bridge = window.boardown;
+
+const SIDEBAR_MIN = 200;
+const SIDEBAR_MAX = 480;
+const SIDEBAR_DEFAULT = 240;
+const SIDEBAR_WIDTH_KEY = 'boardown:sidebar-width';
+
+function clampWidth(value: number): number {
+  return Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, value));
+}
+
+function readStoredWidth(): number {
+  // Number(null) === 0 (key absent) fails the > 0 guard and falls back to default.
+  const stored = Number(localStorage.getItem(SIDEBAR_WIDTH_KEY));
+  return Number.isFinite(stored) && stored > 0 ? clampWidth(stored) : SIDEBAR_DEFAULT;
+}
 
 // Claude-Desktop-style shell: a persistent left sidebar lists the known projects
 // (the persisted recent folders); the main area shows the active project's
@@ -26,6 +47,37 @@ export function Root() {
     openFolderRef.current = activeFolder;
     openThemeRef.current = theme;
   }
+
+  const [sidebarWidth, setSidebarWidth] = useState(readStoredWidth);
+  const draggingRef = useRef(false);
+  const widthRef = useRef(sidebarWidth);
+
+  // Resize via pointer capture on the handle itself: capture serialises the
+  // pointer stream (no accumulating or leaked window listeners) and keeps moves
+  // flowing even past the window edge. Persist the displayed width on release.
+  const onResizeStart = useCallback((event: ReactPointerEvent) => {
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    draggingRef.current = true;
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+  }, []);
+
+  const onResizeMove = useCallback((event: ReactPointerEvent) => {
+    if (!draggingRef.current) return;
+    const width = clampWidth(event.clientX);
+    widthRef.current = width;
+    setSidebarWidth(width);
+  }, []);
+
+  const onResizeEnd = useCallback((event: ReactPointerEvent) => {
+    if (!draggingRef.current) return;
+    draggingRef.current = false;
+    event.currentTarget.releasePointerCapture(event.pointerId);
+    document.body.style.removeProperty('cursor');
+    document.body.style.removeProperty('user-select');
+    localStorage.setItem(SIDEBAR_WIDTH_KEY, String(widthRef.current));
+  }, []);
 
   const refreshProjects = useCallback(() => {
     void bridge.getRecents().then(setProjects);
@@ -74,6 +126,7 @@ export function Root() {
       <Sidebar
         projects={projects}
         activeFolder={activeFolder}
+        width={sidebarWidth}
         onSelect={(folder) => {
           if (folder !== activeFolder) void bridge.openRecent(folder);
         }}
@@ -83,6 +136,15 @@ export function Root() {
         }}
         themeChoice={themeChoice}
         onThemeChoice={chooseTheme}
+      />
+      <div
+        className={styles.resizer}
+        onPointerDown={onResizeStart}
+        onPointerMove={onResizeMove}
+        onPointerUp={onResizeEnd}
+        role="separator"
+        aria-orientation="vertical"
+        aria-label="Resize sidebar"
       />
       <main className={styles.main}>
         {activeFolder === null ? (

--- a/packages/electron/src/renderer/Root.tsx
+++ b/packages/electron/src/renderer/Root.tsx
@@ -1,0 +1,109 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { App } from '@boardown/ui';
+import type { ProjectEntry } from '../bridge';
+import { Sidebar } from './Sidebar';
+import { folderName, suggestIdPrefix } from './project-name';
+import styles from './Root.module.css';
+
+const bridge = window.boardown;
+
+// Claude-Desktop-style shell: a persistent left sidebar lists the known projects
+// (the persisted recent folders); the main area shows the active project's
+// @boardown/ui board, or an empty state when none is selected.
+export function Root() {
+  const [activeFolder, setActiveFolder] = useState<string | null>(bridge.initialFolder);
+  const [theme, setTheme] = useState(bridge.theme);
+  const [projects, setProjects] = useState<ProjectEntry[]>([]);
+
+  // App's defaultTheme only seeds a brand-new board's onboarding; it must stay
+  // stable for each mount, or an OS theme change (which updates `theme`) would
+  // re-fire App's load effect and reload the board mid-edit. Re-capture the
+  // current theme only when the board changes (App is keyed by activeFolder).
+  const openThemeRef = useRef(theme);
+  const openFolderRef = useRef(activeFolder);
+  if (openFolderRef.current !== activeFolder) {
+    openFolderRef.current = activeFolder;
+    openThemeRef.current = theme;
+  }
+
+  const refreshProjects = useCallback(() => {
+    void bridge.getRecents().then(setProjects);
+  }, []);
+
+  useEffect(() => {
+    refreshProjects();
+  }, [refreshProjects]);
+
+  // The host sets the board root before emitting boardOpened, so the App can
+  // mount and hit fs straight away. Refresh the list so a freshly opened folder
+  // shows up (and jumps to the top) in the sidebar.
+  useEffect(
+    () =>
+      bridge.onBoardOpened((folder) => {
+        setActiveFolder(folder);
+        refreshProjects();
+      }),
+    [refreshProjects],
+  );
+  useEffect(() => bridge.onBoardClosed(() => setActiveFolder(null)), []);
+  useEffect(() => bridge.onThemeChange(setTheme), []);
+
+  // With no board mounted, @boardown/ui's theme.css isn't loaded; keep the shell
+  // palette in sync with the OS theme. Once App mounts it drives data-theme from
+  // the board's own config.
+  useEffect(() => {
+    if (activeFolder === null) {
+      document.documentElement.setAttribute('data-theme', theme);
+    }
+  }, [activeFolder, theme]);
+
+  return (
+    <div className={styles.layout}>
+      <Sidebar
+        projects={projects}
+        activeFolder={activeFolder}
+        onSelect={(folder) => {
+          if (folder !== activeFolder) void bridge.openRecent(folder);
+        }}
+        onOpenFolder={() => void bridge.pickFolder()}
+        onRemove={(folder) => {
+          void bridge.removeRecent(folder).then(refreshProjects);
+        }}
+      />
+      <main className={styles.main}>
+        {activeFolder === null ? (
+          <div className={styles.empty}>
+            <p className={styles.emptyTitle}>No project open</p>
+            <p className={styles.emptyHint}>
+              Pick a project on the left, or open a folder to load its board.
+            </p>
+            <button
+              type="button"
+              className={styles.emptyButton}
+              onClick={() => void bridge.pickFolder()}
+            >
+              Open Folder…
+            </button>
+          </div>
+        ) : (
+          <App
+            key={activeFolder}
+            fs={bridge.fs}
+            defaultTheme={openThemeRef.current}
+            defaultProjectName={folderName(activeFolder)}
+            defaultIdPrefix={suggestIdPrefix(folderName(activeFolder))}
+            onCancel={() => {
+              // Always return to the welcome screen, even if the recents cleanup
+              // fails — the host has already dropped this window's board context.
+              const reset = () => {
+                setActiveFolder(null);
+                refreshProjects();
+              };
+              void bridge.cancelBoard().then(reset, reset);
+            }}
+          />
+        )}
+      </main>
+    </div>
+  );
+}

--- a/packages/electron/src/renderer/Root.tsx
+++ b/packages/electron/src/renderer/Root.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { App } from '@boardown/ui';
-import type { ProjectEntry } from '../bridge';
+import type { ProjectEntry, ThemeChoice } from '../bridge';
 import { Sidebar } from './Sidebar';
 import { folderName, suggestIdPrefix } from './project-name';
 import styles from './Root.module.css';
@@ -14,6 +14,7 @@ export function Root() {
   const [activeFolder, setActiveFolder] = useState<string | null>(bridge.initialFolder);
   const [theme, setTheme] = useState(bridge.theme);
   const [projects, setProjects] = useState<ProjectEntry[]>([]);
+  const [themeChoice, setThemeChoiceState] = useState<ThemeChoice>(bridge.themeChoice);
 
   // App's defaultTheme only seeds a brand-new board's onboarding; it must stay
   // stable for each mount, or an OS theme change (which updates `theme`) would
@@ -29,6 +30,17 @@ export function Root() {
   const refreshProjects = useCallback(() => {
     void bridge.getRecents().then(setProjects);
   }, []);
+
+  const chooseTheme = useCallback(
+    (choice: ThemeChoice) => {
+      const previous = themeChoice;
+      setThemeChoiceState(choice);
+      // Revert if the host fails to persist, so the UI never shows a choice that
+      // wasn't actually saved.
+      void bridge.setThemeChoice(choice).catch(() => setThemeChoiceState(previous));
+    },
+    [themeChoice],
+  );
 
   useEffect(() => {
     refreshProjects();
@@ -69,6 +81,8 @@ export function Root() {
         onRemove={(folder) => {
           void bridge.removeRecent(folder).then(refreshProjects);
         }}
+        themeChoice={themeChoice}
+        onThemeChoice={chooseTheme}
       />
       <main className={styles.main}>
         {activeFolder === null ? (
@@ -89,6 +103,7 @@ export function Root() {
           <App
             key={activeFolder}
             fs={bridge.fs}
+            forcedTheme={theme}
             defaultTheme={openThemeRef.current}
             defaultProjectName={folderName(activeFolder)}
             defaultIdPrefix={suggestIdPrefix(folderName(activeFolder))}

--- a/packages/electron/src/renderer/Sidebar.module.css
+++ b/packages/electron/src/renderer/Sidebar.module.css
@@ -4,9 +4,14 @@
   flex-shrink: 0;
   width: 240px;
   height: 100vh;
-  overflow-y: auto;
+  overflow: hidden;
   background: var(--shell-sidebar-bg);
   border-right: 1px solid var(--shell-border);
+}
+
+.scroll {
+  flex: 1;
+  overflow-y: auto;
 }
 
 .header {
@@ -161,4 +166,74 @@
   padding: 8px 16px;
   font-size: 12px;
   color: var(--shell-text-muted);
+}
+
+.footer {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  padding: 8px;
+  border-top: 1px solid var(--shell-border);
+}
+
+.settingsButton {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--shell-text);
+  font-size: 13px;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+}
+
+.settingsButton:hover {
+  background: var(--shell-item-hover);
+}
+
+.settingsPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 8px 10px 12px;
+}
+
+.settingsLabel {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--shell-text-muted);
+}
+
+.themeOptions {
+  display: flex;
+  gap: 4px;
+}
+
+.themeOption {
+  flex: 1;
+  padding: 6px 4px;
+  border: 1px solid var(--shell-border);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--shell-text);
+  font-size: 12px;
+  cursor: pointer;
+}
+
+.themeOption:hover {
+  background: var(--shell-item-hover);
+}
+
+.themeOptionActive,
+.themeOptionActive:hover {
+  border-color: transparent;
+  background: var(--shell-active-bg);
+  color: var(--shell-active-fg);
 }

--- a/packages/electron/src/renderer/Sidebar.module.css
+++ b/packages/electron/src/renderer/Sidebar.module.css
@@ -2,7 +2,7 @@
   display: flex;
   flex-direction: column;
   flex-shrink: 0;
-  width: 240px;
+  /* width comes from the shell as an inline style (resizable + persisted). */
   height: 100vh;
   overflow: hidden;
   background: var(--shell-sidebar-bg);
@@ -11,6 +11,7 @@
 
 .scroll {
   flex: 1;
+  overflow-x: hidden;
   overflow-y: auto;
 }
 
@@ -101,6 +102,7 @@
   flex-direction: column;
   gap: 2px;
   width: 100%;
+  min-width: 0;
   padding: 8px 10px;
   border: none;
   border-radius: 6px;
@@ -129,6 +131,7 @@
 
 .name {
   flex: 1;
+  min-width: 0;
   overflow: hidden;
   font-size: 13px;
   font-weight: 500;
@@ -149,6 +152,8 @@
 }
 
 .path {
+  min-width: 0;
+  max-width: 100%;
   overflow: hidden;
   font-size: 11px;
   color: var(--shell-text-muted);

--- a/packages/electron/src/renderer/Sidebar.module.css
+++ b/packages/electron/src/renderer/Sidebar.module.css
@@ -1,0 +1,164 @@
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  width: 240px;
+  height: 100vh;
+  overflow-y: auto;
+  background: var(--shell-sidebar-bg);
+  border-right: 1px solid var(--shell-border);
+}
+
+.header {
+  padding: 16px 12px 8px;
+}
+
+.title {
+  margin: 0 0 12px;
+  padding: 0 4px;
+  font-size: 16px;
+  font-weight: 700;
+  color: var(--shell-text);
+}
+
+.openButton {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid var(--shell-border);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--shell-text);
+  font-size: 13px;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+}
+
+.openButton:hover {
+  background: var(--shell-item-hover);
+}
+
+.sectionLabel {
+  padding: 12px 16px 4px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--shell-text-muted);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  margin: 0;
+  padding: 0 8px 8px;
+  list-style: none;
+}
+
+.row {
+  position: relative;
+}
+
+.remove {
+  position: absolute;
+  top: 50%;
+  right: 8px;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: var(--shell-item-hover);
+  color: var(--shell-text-muted);
+  font-size: 16px;
+  line-height: 1;
+  cursor: pointer;
+  opacity: 0;
+}
+
+.row:hover .remove,
+.remove:focus-visible {
+  opacity: 1;
+}
+
+.remove:hover {
+  background: var(--shell-border);
+  color: var(--shell-text);
+}
+
+.item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+  padding: 8px 10px;
+  border: none;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--shell-text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.item:hover {
+  background: var(--shell-item-hover);
+}
+
+.itemActive,
+.itemActive:hover {
+  background: var(--shell-active-bg);
+  color: var(--shell-active-fg);
+}
+
+.nameRow {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.name {
+  flex: 1;
+  overflow: hidden;
+  font-size: 13px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.badge {
+  flex-shrink: 0;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  background: var(--shell-badge-bg);
+  color: var(--shell-badge-fg);
+}
+
+.path {
+  overflow: hidden;
+  font-size: 11px;
+  color: var(--shell-text-muted);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.itemActive .path {
+  color: inherit;
+  opacity: 0.75;
+}
+
+.emptyList {
+  margin: 0;
+  padding: 8px 16px;
+  font-size: 12px;
+  color: var(--shell-text-muted);
+}

--- a/packages/electron/src/renderer/Sidebar.tsx
+++ b/packages/electron/src/renderer/Sidebar.tsx
@@ -1,0 +1,73 @@
+import type { ProjectEntry } from '../bridge';
+import styles from './Sidebar.module.css';
+
+interface SidebarProps {
+  projects: ProjectEntry[];
+  activeFolder: string | null;
+  onSelect: (folder: string) => void;
+  onOpenFolder: () => void;
+  onRemove: (folder: string) => void;
+}
+
+export function Sidebar({
+  projects,
+  activeFolder,
+  onSelect,
+  onOpenFolder,
+  onRemove,
+}: SidebarProps) {
+  // Stable alphabetical order so selecting a project never makes it jump in the
+  // list (recents are stored most-recent-first; we don't reorder on click).
+  const sorted = [...projects].sort(
+    (a, b) => a.name.localeCompare(b.name) || a.folder.localeCompare(b.folder),
+  );
+
+  return (
+    <aside className={styles.sidebar}>
+      <div className={styles.header}>
+        <h1 className={styles.title}>boardown</h1>
+        <button type="button" className={styles.openButton} onClick={onOpenFolder}>
+          + Open Folder…
+        </button>
+      </div>
+      <div className={styles.sectionLabel}>Projects</div>
+      {sorted.length === 0 ? (
+        <p className={styles.emptyList}>No projects yet — open a folder to start.</p>
+      ) : (
+        <ul className={styles.list}>
+          {sorted.map((project) => {
+            const active = project.folder === activeFolder;
+            return (
+              <li key={project.folder} className={styles.row}>
+                <button
+                  type="button"
+                  className={active ? `${styles.item} ${styles.itemActive}` : styles.item}
+                  onClick={() => onSelect(project.folder)}
+                  title={project.folder}
+                  aria-current={active || undefined}
+                >
+                  <span className={styles.nameRow}>
+                    <span className={styles.name}>{project.name}</span>
+                    {!project.hasBoard && <span className={styles.badge}>Needs setup</span>}
+                  </span>
+                  <span className={styles.path}>{project.folder}</span>
+                </button>
+                {!active && (
+                  <button
+                    type="button"
+                    className={styles.remove}
+                    onClick={() => onRemove(project.folder)}
+                    title="Remove from list"
+                    aria-label={`Remove ${project.name} from the list`}
+                  >
+                    ×
+                  </button>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </aside>
+  );
+}

--- a/packages/electron/src/renderer/Sidebar.tsx
+++ b/packages/electron/src/renderer/Sidebar.tsx
@@ -6,6 +6,7 @@ import styles from './Sidebar.module.css';
 interface SidebarProps {
   projects: ProjectEntry[];
   activeFolder: string | null;
+  width: number;
   onSelect: (folder: string) => void;
   onOpenFolder: () => void;
   onRemove: (folder: string) => void;
@@ -22,6 +23,7 @@ const THEME_OPTIONS: ReadonlyArray<{ value: ThemeChoice; label: string }> = [
 export function Sidebar({
   projects,
   activeFolder,
+  width,
   onSelect,
   onOpenFolder,
   onRemove,
@@ -37,7 +39,7 @@ export function Sidebar({
   );
 
   return (
-    <aside className={styles.sidebar}>
+    <aside className={styles.sidebar} style={{ width }}>
       <div className={styles.header}>
         <h1 className={styles.title}>boardown</h1>
         <button type="button" className={styles.openButton} onClick={onOpenFolder}>

--- a/packages/electron/src/renderer/Sidebar.tsx
+++ b/packages/electron/src/renderer/Sidebar.tsx
@@ -1,4 +1,6 @@
-import type { ProjectEntry } from '../bridge';
+import { useState } from 'react';
+import { Settings } from 'lucide-react';
+import type { ProjectEntry, ThemeChoice } from '../bridge';
 import styles from './Sidebar.module.css';
 
 interface SidebarProps {
@@ -7,7 +9,15 @@ interface SidebarProps {
   onSelect: (folder: string) => void;
   onOpenFolder: () => void;
   onRemove: (folder: string) => void;
+  themeChoice: ThemeChoice;
+  onThemeChoice: (choice: ThemeChoice) => void;
 }
+
+const THEME_OPTIONS: ReadonlyArray<{ value: ThemeChoice; label: string }> = [
+  { value: 'system', label: 'System' },
+  { value: 'light', label: 'Light' },
+  { value: 'dark', label: 'Dark' },
+];
 
 export function Sidebar({
   projects,
@@ -15,7 +25,11 @@ export function Sidebar({
   onSelect,
   onOpenFolder,
   onRemove,
+  themeChoice,
+  onThemeChoice,
 }: SidebarProps) {
+  const [settingsOpen, setSettingsOpen] = useState(false);
+
   // Stable alphabetical order so selecting a project never makes it jump in the
   // list (recents are stored most-recent-first; we don't reorder on click).
   const sorted = [...projects].sort(
@@ -30,44 +44,81 @@ export function Sidebar({
           + Open Folder…
         </button>
       </div>
-      <div className={styles.sectionLabel}>Projects</div>
-      {sorted.length === 0 ? (
-        <p className={styles.emptyList}>No projects yet — open a folder to start.</p>
-      ) : (
-        <ul className={styles.list}>
-          {sorted.map((project) => {
-            const active = project.folder === activeFolder;
-            return (
-              <li key={project.folder} className={styles.row}>
-                <button
-                  type="button"
-                  className={active ? `${styles.item} ${styles.itemActive}` : styles.item}
-                  onClick={() => onSelect(project.folder)}
-                  title={project.folder}
-                  aria-current={active || undefined}
-                >
-                  <span className={styles.nameRow}>
-                    <span className={styles.name}>{project.name}</span>
-                    {!project.hasBoard && <span className={styles.badge}>Needs setup</span>}
-                  </span>
-                  <span className={styles.path}>{project.folder}</span>
-                </button>
-                {!active && (
+
+      <div className={styles.scroll}>
+        <div className={styles.sectionLabel}>Projects</div>
+        {sorted.length === 0 ? (
+          <p className={styles.emptyList}>No projects yet — open a folder to start.</p>
+        ) : (
+          <ul className={styles.list}>
+            {sorted.map((project) => {
+              const active = project.folder === activeFolder;
+              return (
+                <li key={project.folder} className={styles.row}>
                   <button
                     type="button"
-                    className={styles.remove}
-                    onClick={() => onRemove(project.folder)}
-                    title="Remove from list"
-                    aria-label={`Remove ${project.name} from the list`}
+                    className={active ? `${styles.item} ${styles.itemActive}` : styles.item}
+                    onClick={() => onSelect(project.folder)}
+                    title={project.folder}
+                    aria-current={active || undefined}
                   >
-                    ×
+                    <span className={styles.nameRow}>
+                      <span className={styles.name}>{project.name}</span>
+                      {!project.hasBoard && <span className={styles.badge}>Needs setup</span>}
+                    </span>
+                    <span className={styles.path}>{project.folder}</span>
                   </button>
-                )}
-              </li>
-            );
-          })}
-        </ul>
-      )}
+                  {!active && (
+                    <button
+                      type="button"
+                      className={styles.remove}
+                      onClick={() => onRemove(project.folder)}
+                      title="Remove from list"
+                      aria-label={`Remove ${project.name} from the list`}
+                    >
+                      ×
+                    </button>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <div className={styles.footer}>
+        {settingsOpen && (
+          <div className={styles.settingsPanel}>
+            <span className={styles.settingsLabel}>Theme</span>
+            <div className={styles.themeOptions}>
+              {THEME_OPTIONS.map(({ value, label }) => (
+                <button
+                  key={value}
+                  type="button"
+                  className={
+                    value === themeChoice
+                      ? `${styles.themeOption} ${styles.themeOptionActive}`
+                      : styles.themeOption
+                  }
+                  onClick={() => onThemeChoice(value)}
+                  aria-pressed={value === themeChoice}
+                >
+                  {label}
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+        <button
+          type="button"
+          className={styles.settingsButton}
+          onClick={() => setSettingsOpen((open) => !open)}
+          aria-expanded={settingsOpen}
+        >
+          <Settings size={16} aria-hidden="true" />
+          Settings
+        </button>
+      </div>
     </aside>
   );
 }

--- a/packages/electron/src/renderer/main.tsx
+++ b/packages/electron/src/renderer/main.tsx
@@ -1,0 +1,20 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './shell-theme.css';
+import { Root } from './Root';
+
+// Stamp the theme before React's first render so the welcome screen never
+// flashes the light palette on a dark system — the entry module runs before any
+// paint of #root's contents, and the bridge knows the theme synchronously.
+document.documentElement.setAttribute('data-theme', window.boardown.theme);
+
+const container = document.getElementById('root');
+if (!container) {
+  throw new Error('Root container #root not found');
+}
+
+createRoot(container).render(
+  <StrictMode>
+    <Root />
+  </StrictMode>,
+);

--- a/packages/electron/src/renderer/project-name.test.ts
+++ b/packages/electron/src/renderer/project-name.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { folderName, suggestIdPrefix } from './project-name';
+
+describe('folderName', () => {
+  it('returns the last segment of a POSIX path', () => {
+    expect(folderName('/Users/me/gamedev/html-game')).toBe('html-game');
+  });
+
+  it('returns the last segment of a Windows path', () => {
+    expect(folderName('C:\\Users\\me\\html-game')).toBe('html-game');
+  });
+
+  it('ignores a trailing separator', () => {
+    expect(folderName('/Users/me/proj/')).toBe('proj');
+  });
+
+  it('returns the input when there is no separator', () => {
+    expect(folderName('proj')).toBe('proj');
+  });
+});
+
+describe('suggestIdPrefix', () => {
+  it('uses word initials for a multi-word name', () => {
+    expect(suggestIdPrefix('boardown-demo-empty')).toBe('BDE');
+  });
+
+  it('drops trailing digits when splitting into words', () => {
+    expect(suggestIdPrefix('html-game-2')).toBe('HG');
+  });
+
+  it('uses the leading letters of a single word', () => {
+    expect(suggestIdPrefix('demo')).toBe('DEMO');
+  });
+
+  it('caps the prefix at five letters', () => {
+    expect(suggestIdPrefix('superlongprojectname')).toBe('SUPER');
+  });
+
+  it('returns empty when there are too few letters to be valid', () => {
+    expect(suggestIdPrefix('x')).toBe('');
+    expect(suggestIdPrefix('123')).toBe('');
+    expect(suggestIdPrefix('')).toBe('');
+  });
+});

--- a/packages/electron/src/renderer/project-name.ts
+++ b/packages/electron/src/renderer/project-name.ts
@@ -1,0 +1,24 @@
+// Last path segment of a folder — the sidebar's display name and the
+// onboarding's project-name seed. Handles POSIX and Windows separators.
+export function folderName(folder: string): string {
+  return (
+    folder
+      .split(/[/\\]/)
+      .filter((part) => part.length > 0)
+      .pop() ?? folder
+  );
+}
+
+// A valid ID prefix (2–5 uppercase letters) guessed from a folder/project name:
+// initials of its words, or the first letters of a single word. Empty when no
+// usable letters — onboarding then asks for it as before.
+export function suggestIdPrefix(name: string): string {
+  const words = name.split(/[^A-Za-z]+/).filter((word) => word.length > 0);
+  const initials = words
+    .map((word) => word.charAt(0))
+    .join('')
+    .toUpperCase();
+  const base = initials.length >= 2 ? initials : (words[0] ?? '').toUpperCase();
+  const candidate = base.replace(/[^A-Z]/g, '').slice(0, 5);
+  return candidate.length >= 2 ? candidate : '';
+}

--- a/packages/electron/src/renderer/shell-theme.css
+++ b/packages/electron/src/renderer/shell-theme.css
@@ -1,0 +1,56 @@
+/*
+ * Palette + reset for the shell chrome (sidebar, empty state) that is visible
+ * even when no board — and therefore @boardown/ui's theme.css — is mounted.
+ * Tokens are namespaced (`--shell-*`) to avoid clashing with the board palette
+ * and key off [data-theme], so the chrome matches the active board's theme
+ * (App drives data-theme) and falls back to the OS theme when no board is open.
+ */
+:root,
+[data-theme='light'] {
+  --shell-bg: #ffffff;
+  --shell-sidebar-bg: #f3f3f4;
+  --shell-border: #e2e2e5;
+  --shell-text: #202020;
+  --shell-text-muted: #606060;
+  --shell-item-hover: #eaeaea;
+  --shell-active-bg: #e1effa;
+  --shell-active-fg: #00518f;
+  --shell-accent: #0069cc;
+  --shell-accent-fg: #ffffff;
+  --shell-badge-bg: #fdebcd;
+  --shell-badge-fg: #8a5a00;
+}
+
+[data-theme='dark'] {
+  --shell-bg: #121314;
+  --shell-sidebar-bg: #191a1b;
+  --shell-border: #2a2b2c;
+  --shell-text: #bbbebf;
+  --shell-text-muted: #8c8c8c;
+  --shell-item-hover: #2c2d2e;
+  --shell-active-bg: #16323d;
+  --shell-active-fg: #7fc4e3;
+  --shell-accent: #3994bc;
+  --shell-accent-fg: #ffffff;
+  --shell-badge-bg: #352a05;
+  --shell-badge-fg: #e5ba7d;
+}
+
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+body {
+  background: var(--shell-bg);
+  color: var(--shell-text);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}

--- a/packages/electron/tsconfig.json
+++ b/packages/electron/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "jsx": "react-jsx",
+    "noEmit": true,
+    "types": ["node", "vite/client"]
+  },
+  "include": ["src/**/*", "vite.config.ts", "vitest.config.ts"]
+}

--- a/packages/electron/vite.config.ts
+++ b/packages/electron/vite.config.ts
@@ -1,0 +1,18 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+// base './' so the packaged index.html references its assets relatively — the
+// main process loads it over file://, where absolute '/assets/…' would 404.
+export default defineConfig({
+  root: here,
+  base: './',
+  plugins: [react()],
+  build: {
+    outDir: 'dist/renderer',
+    emptyOutDir: true,
+  },
+});

--- a/packages/electron/vitest.config.ts
+++ b/packages/electron/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -33,6 +33,10 @@ interface AppProps {
   // When provided, onboarding can be cancelled (shells with somewhere to go
   // back to, e.g. the desktop sidebar). Omitted by web/vscode.
   onCancel?: () => void;
+  // When provided, the shell owns the theme app-wide: this value drives
+  // data-theme and the board's own config.theme is ignored for display. The
+  // per-board theme control is hidden so there is a single source of truth.
+  forcedTheme?: Theme;
 }
 
 export function App({
@@ -41,6 +45,7 @@ export function App({
   defaultProjectName,
   defaultIdPrefix,
   onCancel,
+  forcedTheme,
 }: AppProps) {
   const status = useBoardStore((s) => s.status);
   const snapshot = useBoardStore((s) => s.snapshot);
@@ -85,9 +90,10 @@ export function App({
   // config and wins.
   useLayoutEffect(() => {
     const resolved =
-      status === 'idle' || status === 'loading' ? (defaultTheme ?? theme) : theme;
+      forcedTheme ??
+      (status === 'idle' || status === 'loading' ? (defaultTheme ?? theme) : theme);
     document.documentElement.setAttribute('data-theme', resolved);
-  }, [theme, defaultTheme, status]);
+  }, [theme, defaultTheme, forcedTheme, status]);
 
   if (status === 'idle' || status === 'loading') {
     return (
@@ -155,7 +161,11 @@ export function App({
       <header className={styles.header}>
         <h1>{snapshot.config.projectName}</h1>
       </header>
-      <TabBar activeTab={activeTab} onSelect={setActiveTab} />
+      <TabBar
+        activeTab={activeTab}
+        onSelect={setActiveTab}
+        hideSettings={forcedTheme !== undefined}
+      />
       <TabContent
         activeTab={activeTab}
         releases={snapshot.releases}
@@ -223,7 +233,7 @@ export function App({
           onClose={closeStartRelease}
         />
       )}
-      {settingsOpen && <SettingsDialog onClose={closeSettings} />}
+      {settingsOpen && !forcedTheme && <SettingsDialog onClose={closeSettings} />}
       {conflictOpen && <ConflictDialog />}
     </main>
   );

--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -25,9 +25,23 @@ interface AppProps {
   // Host-provided fallback theme (e.g. VS Code's color theme). Seeds the theme
   // only when onboarding writes a brand-new config; ignored once a board exists.
   defaultTheme?: Theme;
+  // Host-provided seeds for the onboarding form (e.g. the opened folder's name
+  // and a prefix derived from it). Used only when a brand-new board runs
+  // onboarding; ignored once a board exists.
+  defaultProjectName?: string;
+  defaultIdPrefix?: string;
+  // When provided, onboarding can be cancelled (shells with somewhere to go
+  // back to, e.g. the desktop sidebar). Omitted by web/vscode.
+  onCancel?: () => void;
 }
 
-export function App({ fs, defaultTheme }: AppProps) {
+export function App({
+  fs,
+  defaultTheme,
+  defaultProjectName,
+  defaultIdPrefix,
+  onCancel,
+}: AppProps) {
   const status = useBoardStore((s) => s.status);
   const snapshot = useBoardStore((s) => s.snapshot);
   const problems = useBoardStore((s) => s.problems);
@@ -92,7 +106,11 @@ export function App({ fs, defaultTheme }: AppProps) {
         <header className={styles.header}>
           <h1 />
         </header>
-        <OnboardingDialog />
+        <OnboardingDialog
+          defaultProjectName={defaultProjectName ?? ''}
+          defaultIdPrefix={defaultIdPrefix ?? ''}
+          {...(onCancel ? { onCancel } : {})}
+        />
       </main>
     );
   }

--- a/packages/ui/src/components/OnboardingDialog.module.css
+++ b/packages/ui/src/components/OnboardingDialog.module.css
@@ -102,6 +102,32 @@
   margin-top: 4px;
 }
 
+.cancelButton {
+  font: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  padding: 8px 16px;
+  border-radius: 6px;
+  cursor: pointer;
+  border: 1px solid var(--card-border);
+  background: var(--surface);
+  color: var(--text-secondary);
+}
+
+.cancelButton:hover:not(:disabled) {
+  background: var(--surface-muted);
+}
+
+.cancelButton:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.cancelButton:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 .createButton {
   font: inherit;
   font-size: 13px;

--- a/packages/ui/src/components/OnboardingDialog.tsx
+++ b/packages/ui/src/components/OnboardingDialog.tsx
@@ -6,11 +6,27 @@ import styles from './OnboardingDialog.module.css';
 
 const noop = () => {};
 
-export function OnboardingDialog() {
+interface OnboardingDialogProps {
+  // Host-provided seeds (e.g. derived from the opened folder); empty when the
+  // shell has no hint to offer.
+  defaultProjectName?: string;
+  defaultIdPrefix?: string;
+  // When provided, the form can be cancelled (button + ESC/backdrop) instead of
+  // being a required first step — used by shells where there is somewhere to go
+  // back to (e.g. the desktop sidebar). Omitted by web/vscode, where the board
+  // is the whole window and onboarding is mandatory.
+  onCancel?: () => void;
+}
+
+export function OnboardingDialog({
+  defaultProjectName,
+  defaultIdPrefix,
+  onCancel,
+}: OnboardingDialogProps) {
   const completeOnboarding = useBoardStore((s) => s.completeOnboarding);
 
-  const [projectName, setProjectName] = useState('');
-  const [idPrefix, setIdPrefix] = useState('');
+  const [projectName, setProjectName] = useState(defaultProjectName ?? '');
+  const [idPrefix, setIdPrefix] = useState(defaultIdPrefix ?? '');
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
 
@@ -37,10 +53,10 @@ export function OnboardingDialog() {
   return (
     <Modal
       open
-      onClose={noop}
+      onClose={onCancel ?? noop}
       ariaLabel="Welcome to Boardown"
       className={styles.dialog}
-      dismissable={false}
+      dismissable={onCancel !== undefined}
     >
       <header className={styles.header}>
         <h2 className={styles.title}>Welcome to Boardown</h2>
@@ -89,6 +105,16 @@ export function OnboardingDialog() {
           </p>
         )}
         <footer className={styles.footer}>
+          {onCancel && (
+            <button
+              type="button"
+              className={styles.cancelButton}
+              onClick={onCancel}
+              disabled={submitting}
+            >
+              Cancel
+            </button>
+          )}
           <button type="submit" className={styles.createButton} disabled={!canSubmit}>
             {submitting ? 'Creating…' : 'Create'}
           </button>

--- a/packages/ui/src/components/TabBar.tsx
+++ b/packages/ui/src/components/TabBar.tsx
@@ -8,6 +8,9 @@ import styles from './TabBar.module.css';
 interface TabBarProps {
   activeTab: ActiveTab;
   onSelect: (tab: ActiveTab) => void;
+  // Hosts that own the theme themselves (e.g. the desktop shell) hide the
+  // per-board settings, whose only control is the theme.
+  hideSettings?: boolean;
 }
 
 const TABS: ReadonlyArray<{ key: ActiveTab; label: string; icon: LucideIcon }> = [
@@ -19,7 +22,7 @@ const TABS: ReadonlyArray<{ key: ActiveTab; label: string; icon: LucideIcon }> =
 const tabClass = (active: boolean): string =>
   [styles.tab, active && styles.tabActive].filter(Boolean).join(' ');
 
-export function TabBar({ activeTab, onSelect }: TabBarProps) {
+export function TabBar({ activeTab, onSelect, hideSettings }: TabBarProps) {
   return (
     <div className={styles.bar}>
       <div className={styles.tabs}>
@@ -38,7 +41,7 @@ export function TabBar({ activeTab, onSelect }: TabBarProps) {
       <div className={styles.actions}>
         <CreateMenu />
         <ReloadButton />
-        <SettingsButton />
+        {!hideSettings && <SettingsButton />}
       </div>
     </div>
   );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,49 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@20.19.39)
 
+  packages/electron:
+    dependencies:
+      '@boardown/core':
+        specifier: workspace:*
+        version: link:../core
+      '@boardown/ui':
+        specifier: workspace:*
+        version: link:../ui
+      react:
+        specifier: ^18.3.1
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.3.1
+        version: 18.3.1(react@18.3.1)
+    devDependencies:
+      '@types/node':
+        specifier: ^20.17.10
+        version: 20.19.39
+      '@types/react':
+        specifier: ^18.3.18
+        version: 18.3.28
+      '@types/react-dom':
+        specifier: ^18.3.5
+        version: 18.3.7(@types/react@18.3.28)
+      '@vitejs/plugin-react':
+        specifier: ^4.3.4
+        version: 4.7.0(vite@6.4.2(@types/node@20.19.39))
+      electron:
+        specifier: ^33.0.0
+        version: 33.4.11
+      electron-builder:
+        specifier: ^25.1.8
+        version: 25.1.8(electron-builder-squirrel-windows@25.1.8)
+      esbuild:
+        specifier: ^0.24.0
+        version: 0.24.2
+      vite:
+        specifier: ^6.0.3
+        version: 6.4.2(@types/node@20.19.39)
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@20.19.39)
+
   packages/ui:
     dependencies:
       '@boardown/core':
@@ -164,6 +207,9 @@ importers:
         version: 6.4.2(@types/node@20.19.39)
 
 packages:
+
+  7zip-bin@5.2.0:
+    resolution: {integrity: sha512-ukTPVhqG4jNzMro2qA9HSCSSVJN3aN7tlb+hfqYCt3ER0yWroeA2VR38MNrOHLQ/cVj+DaIMad0kFCtWWowh/A==}
 
   '@azu/format-text@1.0.2':
     resolution: {integrity: sha512-Swi4N7Edy1Eqq82GxgEECXSSLyn6GOb5htRFPzBDdUkECGXtlf12ynO5oJSpWKPwCaUssOu7NfhDcCWpIC6Ywg==}
@@ -298,6 +344,10 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@develar/schema-utils@2.6.5':
+    resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
+    engines: {node: '>= 8.9.0'}
+
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
     peerDependencies:
@@ -319,6 +369,33 @@ packages:
     resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
     peerDependencies:
       react: '>=16.8.0'
+
+  '@electron/asar@3.4.1':
+    resolution: {integrity: sha512-i4/rNPRS84t0vSRa2HorerGRXWyF4vThfHesw0dmcWHp+cspK743UanA0suA5Q5y8kzY2y6YKrvbIUn69BCAiA==}
+    engines: {node: '>=10.12.0'}
+    hasBin: true
+
+  '@electron/get@2.0.3':
+    resolution: {integrity: sha512-Qkzpg2s9GnVV2I2BjRksUi43U5e6+zaQMcjoJy0C+C5oxaKl+fmckGDQFtRpZpZV0NQekuZZ+tGz7EA9TVnQtQ==}
+    engines: {node: '>=12'}
+
+  '@electron/notarize@2.5.0':
+    resolution: {integrity: sha512-jNT8nwH1f9X5GEITXaQ8IF/KdskvIkOFfB2CvwumsveVidzpSc+mvhhTMdAGSYF3O+Nq49lJ7y+ssODRXu06+A==}
+    engines: {node: '>= 10.0.0'}
+
+  '@electron/osx-sign@1.3.1':
+    resolution: {integrity: sha512-BAfviURMHpmb1Yb50YbCxnOY0wfwaLXH5KJ4+80zS0gUkzDX3ec23naTlEqKsN+PwYn+a1cCzM7BJ4Wcd3sGzw==}
+    engines: {node: '>=12.0.0'}
+    hasBin: true
+
+  '@electron/rebuild@3.6.1':
+    resolution: {integrity: sha512-f6596ZHpEq/YskUd8emYvOUne89ij8mQgjYFA5ru25QwbrRO+t1SImofdDv7kKOuWCmVOuU5tvfkbgGxIl3E/w==}
+    engines: {node: '>=12.13.0'}
+    hasBin: true
+
+  '@electron/universal@2.0.1':
+    resolution: {integrity: sha512-fKpv9kg4SPmt+hY7SVBnIYULE9QJl8L3sCfcBsnqbJwwBwAeTLokJ9TRt9y7bK0JAzIW2y78TVVjvnQEms/yyA==}
+    engines: {node: '>=16.4'}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -802,6 +879,9 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@gar/promisify@1.1.3':
+    resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -821,6 +901,10 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
 
   '@isaacs/cliui@9.0.0':
     resolution: {integrity: sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==}
@@ -842,6 +926,14 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@malept/cross-spawn-promise@2.0.0':
+    resolution: {integrity: sha512-1DpKU0Z5ThltBwjNySMC14g0CkbyhCaz9FkhxqNsZI6uAPJXFS8cMXlBKo26FJ8ZuW6S9GCMcR9IO5k2X5/9Fg==}
+    engines: {node: '>= 12.13.0'}
+
+  '@malept/flatpak-bundler@0.4.0':
+    resolution: {integrity: sha512-9QOtNffcOF/c1seMCDnjckb3R9WHcG34tky+FHpNKKCW0wc/scYLwMtO+ptyGUfMW0/b/n4qRiALlaFHc9Oj7Q==}
+    engines: {node: '>= 10.0.0'}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -853,6 +945,19 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@npmcli/fs@2.1.2':
+    resolution: {integrity: sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  '@npmcli/move-file@2.0.1':
+    resolution: {integrity: sha512-mJd2Z5TjYWq/ttPLLGqArdtnC74J6bOzg4rMDnN+p1xTacZ2yPRCk2y0oSWQtygLR9YVQXgOcONrwtnk3JupxQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This functionality has been moved to @npmcli/fs
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@rolldown/pluginutils@1.0.0-beta.27':
     resolution: {integrity: sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==}
@@ -1040,9 +1145,17 @@ packages:
     resolution: {integrity: sha512-Nqc90v4lWCXyakD6xNyNACBJNJ0tNCwj2WNk/7ivyacYHxiITVgmLUFXTBOeCdy79iz6HtN9Y31uw/jbLrdOAg==}
     engines: {node: '>=20.0.0'}
 
+  '@sindresorhus/is@4.6.0':
+    resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
+    engines: {node: '>=10'}
+
   '@sindresorhus/merge-streams@2.3.0':
     resolution: {integrity: sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==}
     engines: {node: '>=18'}
+
+  '@szmarczak/http-timer@4.0.6':
+    resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
+    engines: {node: '>=10'}
 
   '@textlint/ast-node-types@15.7.1':
     resolution: {integrity: sha512-Wii5UgUKFEh9Uv6wbq1zr4/Kf+dtjiUuzPrrXzKp8H+ifkvKNzi23V4Nz+6wVyHQn5T28AFuc8VH8OtzvGYecA==}
@@ -1059,6 +1172,10 @@ packages:
   '@textlint/types@15.7.1':
     resolution: {integrity: sha512-Vye/GmFNBTgVzZFtIFJTmLB+s2A7oIADxNG6r9UhfPuY+Czv0z5G3xeyFZZudPlfxURsKUyPIU5XsjOFqVp33A==}
 
+  '@tootallnate/once@2.0.1':
+    resolution: {integrity: sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==}
+    engines: {node: '>= 10'}
+
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -1071,8 +1188,20 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/cacheable-request@6.0.3':
+    resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
+
+  '@types/debug@4.1.13':
+    resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/fs-extra@9.0.13':
+    resolution: {integrity: sha512-nEnwB++1u5lVDM2UI4c1+5R+FYaKfaAzS4OococimjVm3nQw3TuzH5UNsocrcTBbhnerblyHj4A49qXbIiZdpA==}
+
+  '@types/http-cache-semantics@4.2.0':
+    resolution: {integrity: sha512-L3LgimLHXtGkWikKnsPg0/VFx9OGZaC+eN1u4r+OB1XRqH3meBIAVC2zr1WdMH+RHmnRkqliQAOHNJ/E0j/e0Q==}
 
   '@types/js-yaml@4.0.9':
     resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
@@ -1080,11 +1209,20 @@ packages:
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
+  '@types/keyv@3.1.4':
+    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
+
+  '@types/ms@2.1.0':
+    resolution: {integrity: sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==}
+
   '@types/node@20.19.39':
     resolution: {integrity: sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/plist@3.0.5':
+    resolution: {integrity: sha512-E6OCaRmAe4WDmWNsL/9RMqdkkzDCY1etutkflWk4c+AcjDU07Pcz1fQwTX0TQz+Pxqn9i4L1TU3UFpjnrcDgxA==}
 
   '@types/prop-types@15.7.15':
     resolution: {integrity: sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==}
@@ -1097,11 +1235,20 @@ packages:
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
 
+  '@types/responselike@1.0.3':
+    resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
   '@types/sarif@2.1.7':
     resolution: {integrity: sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==}
 
+  '@types/verror@1.10.11':
+    resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
+
   '@types/vscode@1.120.0':
     resolution: {integrity: sha512-feaT4Rst+FkTch5zz/ZbNCxoIvo55YU80Be2kiL7OJcod4+CUYf2lUBPdIJzozNnSEMq1VRTGrWEcCGFB3fBmA==}
+
+  '@types/yauzl@2.10.3':
+    resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
 
   '@typescript-eslint/eslint-plugin@8.59.2':
     resolution: {integrity: sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==}
@@ -1254,6 +1401,13 @@ packages:
     engines: {node: '>= 20'}
     hasBin: true
 
+  '@xmldom/xmldom@0.9.10':
+    resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
+    engines: {node: '>=14.6'}
+
+  abbrev@1.1.1:
+    resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1264,9 +1418,26 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@6.0.2:
+    resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
+    engines: {node: '>= 6.0.0'}
+
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
+
+  agentkeepalive@4.6.0:
+    resolution: {integrity: sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==}
+    engines: {node: '>= 8.0.0'}
+
+  aggregate-error@3.1.0:
+    resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
+    engines: {node: '>=8'}
+
+  ajv-keywords@3.5.2:
+    resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
+    peerDependencies:
+      ajv: ^6.9.1
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
@@ -1289,6 +1460,40 @@ packages:
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
+
+  app-builder-bin@5.0.0-alpha.10:
+    resolution: {integrity: sha512-Ev4jj3D7Bo+O0GPD2NMvJl+PGiBAfS7pUGawntBNpCbxtpncfUixqFj9z9Jme7V7s3LBGqsWZZP54fxBX3JKJw==}
+
+  app-builder-lib@25.1.8:
+    resolution: {integrity: sha512-pCqe7dfsQFBABC1jeKZXQWhGcCPF3rPCXDdfqVKjIeWBcXzyC1iOWZdfFhGl+S9MyE/k//DFmC6FzuGAUudNDg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      dmg-builder: 25.1.8
+      electron-builder-squirrel-windows: 25.1.8
+
+  aproba@2.1.0:
+    resolution: {integrity: sha512-tLIEcj5GuR2RSTnxNKdkK0dJ/GrC7P38sUkiDmDuHfsHmbagTFAxDVIBltoklXEVIQ/f14IL8IMJ5pn9Hez1Ew==}
+
+  archiver-utils@2.1.0:
+    resolution: {integrity: sha512-bEL/yUb/fNNiNTuUz979Z0Yg5L+LzLxGJz8x79lYmR54fmTIb6ob/hNQgkQnIUDWIFjZVQwl9Xs356I6BAMHfw==}
+    engines: {node: '>= 6'}
+
+  archiver-utils@3.0.4:
+    resolution: {integrity: sha512-KVgf4XQVrTjhyWmx6cte4RxonPLR9onExufI1jhvw/MQ4BB6IsZD5gT8Lq+u/+pRkWna/6JoHpiQioaqFP5Rzw==}
+    engines: {node: '>= 10'}
+
+  archiver@5.3.2:
+    resolution: {integrity: sha512-+25nxyyznAXF7Nef3y0EbBeqmGZgeN/BxHX29Rs39djAfaFalmQ89SE6CWyDCHzGL0yt/ycBtNOmGTW0FyGWNw==}
+    engines: {node: '>= 10'}
+
+  are-we-there-yet@3.0.1:
+    resolution: {integrity: sha512-QZW4EDmGwlYur0Yyf/b2uGucHQMa8aFUP7eu9ddR73vvhFyt4V0Vl3QHPcTNJ8l6qYOBdxgXdnBXQrHilfRQBg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -1324,6 +1529,10 @@ packages:
     resolution: {integrity: sha512-BNoCY6SXXPQ7gF2opIP4GBE+Xw7U+pHMYKuzjgCN3GwiaIR09UUeKfheyIry77QtrCBlC0KK0q5/TER/tYh3PQ==}
     engines: {node: '>= 0.4'}
 
+  assert-plus@1.0.0:
+    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
+    engines: {node: '>=0.8'}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -1332,12 +1541,23 @@ packages:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
     engines: {node: '>=8'}
 
+  async-exit-hook@2.0.1:
+    resolution: {integrity: sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==}
+    engines: {node: '>=0.12.0'}
+
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
+
+  at-least-node@1.0.0:
+    resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
+    engines: {node: '>= 4.0.0'}
 
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
@@ -1368,14 +1588,27 @@ packages:
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
+  bluebird-lst@1.0.9:
+    resolution: {integrity: sha512-7B1Rtx82hjnSD4PGLAjVWeYH3tHAcVUmChh85a3lltKQm6FresXh9ErQo6oAv6CqxttczC3/kEg8SY5NluPuUw==}
+
+  bluebird@3.7.2:
+    resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
+
   boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
+  boolean@3.2.0:
+    resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   boundary@2.0.0:
     resolution: {integrity: sha512-rJKn5ooC9u8q13IMCrW0RSp31pxBCHE3y9V/tp3TdWSLf8Em3p6Di4NBpfzbJge9YjjFEsD0RtFEjtvHL5VyEA==}
 
   brace-expansion@1.1.14:
     resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+
+  brace-expansion@2.1.1:
+    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
 
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
@@ -1396,8 +1629,18 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
+
+  builder-util-runtime@9.2.10:
+    resolution: {integrity: sha512-6p/gfG1RJSQeIbz8TK5aPNkoztgY1q5TgmGFMAXcY8itsGW6Y2ld1ALsZ5UJn8rog7hKF3zHx5iQbNQ8uLcRlw==}
+    engines: {node: '>=12.0.0'}
+
+  builder-util@25.1.7:
+    resolution: {integrity: sha512-7jPjzBwEGRbwNcep0gGNpLXG9P94VA3CPAZQCzxkFXiV2GMQKlziMbY//rXPI7WKfhsvGgFXjTcXdBEwgXw9ww==}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -1405,6 +1648,18 @@ packages:
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  cacache@16.1.3:
+    resolution: {integrity: sha512-/+Emcj9DAXxX4cwlLmRI9c166RuL3w30zp4R7Joiv2cQTtTtA+jeuCAjH3ZlGnYS3tKENSrKhAzVVP9GVyzeYQ==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  cacheable-lookup@5.0.4:
+    resolution: {integrity: sha512-2/kNscPhpcxrOigMZzbiWF7dz8ilhb/nIHU3EyZiXWXpeq/au8qJ8VhdftMkty3n7Gj6HIGalQG8oiBNB3AJgA==}
+    engines: {node: '>=10.6.0'}
+
+  cacheable-request@7.0.4:
+    resolution: {integrity: sha512-v+p6ongsrp0yTGbJXjgxPow2+DL93DASP4kXCDKb8/bwRtt9OEF3whggkkDkGNzgcWy2XaF4a8nZglC7uElscg==}
     engines: {node: '>=8'}
 
   call-bind-apply-helpers@1.0.2:
@@ -1452,6 +1707,44 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
+  chownr@2.0.0:
+    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
+    engines: {node: '>=10'}
+
+  chromium-pickle-js@0.2.0:
+    resolution: {integrity: sha512-1R5Fho+jBq0DDydt+/vHWj5KJNJCKdARKOCwZUen84I5BreWoLqRLANH1U87eJy1tiASPtMnGqJJq0ZsLoRPOw==}
+
+  ci-info@3.9.0:
+    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
+    engines: {node: '>=8'}
+
+  clean-stack@2.2.0:
+    resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
+    engines: {node: '>=6'}
+
+  cli-cursor@3.1.0:
+    resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
+    engines: {node: '>=8'}
+
+  cli-spinners@2.9.2:
+    resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
+    engines: {node: '>=6'}
+
+  cli-truncate@2.1.0:
+    resolution: {integrity: sha512-n8fOixwDD6b/ObinzTrp1ZKFzbgvKZvuz/TvejnLn1aQfC6r52XEx85FmuC+3HI+JM7coBRXUvNqEU2PHVrHpg==}
+    engines: {node: '>=8'}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
+
+  clone-response@1.0.3:
+    resolution: {integrity: sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==}
+
+  clone@1.0.4:
+    resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
+    engines: {node: '>=0.8'}
+
   cockatiel@3.2.1:
     resolution: {integrity: sha512-gfrHV6ZPkquExvMh9IOkKsBzNDk6sDuZ6DdBGUBkvFnTCqCxzpuq48RySgP0AnaqQkw2zynOFj9yly6T1Q2G5Q==}
     engines: {node: '>=16'}
@@ -1463,6 +1756,10 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  color-support@1.1.3:
+    resolution: {integrity: sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==}
+    hasBin: true
+
   combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
@@ -1471,11 +1768,47 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
+  commander@5.1.0:
+    resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
+    engines: {node: '>= 6'}
+
+  compare-version@0.1.2:
+    resolution: {integrity: sha512-pJDh5/4wrEnXX/VWRZvruAGHkzKdr46z11OlTPN+VrATlWWhSKewNCJ1futCO5C7eJB3nPMFZA1LeYtcFboZ2A==}
+    engines: {node: '>=0.10.0'}
+
+  compress-commons@4.1.2:
+    resolution: {integrity: sha512-D3uMHtGc/fcO1Gt1/L7i1e33VOvD4A9hfQLP+6ewd+BvG/gQ84Yh4oftEhAdjSMgBgwGL+jsppT7JYNpo6MHHg==}
+    engines: {node: '>= 10'}
+
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  config-file-ts@0.2.8-rc1:
+    resolution: {integrity: sha512-GtNECbVI82bT4RiDIzBSVuTKoSHufnU7Ce7/42bkWZJZFLjmDF2WBpVsvRkhKCfKBnTBb3qZrBwPpFBU/Myvhg==}
+
+  console-control-strings@1.1.0:
+    resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  core-util-is@1.0.2:
+    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
+
+  core-util-is@1.0.3:
+    resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  crc-32@1.2.2:
+    resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
+    engines: {node: '>=0.8'}
+    hasBin: true
+
+  crc32-stream@4.0.3:
+    resolution: {integrity: sha512-NT7w2JVU7DFroFdYkeq8cywxrgjPHWkdX1wjpRQXPX5Asews3tA+Ght6lddQO5Mkumffp3X7GEqku3epj2toIw==}
+    engines: {node: '>= 10'}
+
+  crc@3.8.0:
+    resolution: {integrity: sha512-iX3mfgcTMIq3ZKLIsVFAbv7+Mc10kxabAGQb8HvjA1o3T1PIYprbakQ65d3I+2HGHt6nSKkM9PYjgoJO2KcFBQ==}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1535,6 +1868,13 @@ packages:
     resolution: {integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==}
     engines: {node: '>=18'}
 
+  defaults@1.0.4:
+    resolution: {integrity: sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==}
+
+  defer-to-connect@2.0.1:
+    resolution: {integrity: sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==}
+    engines: {node: '>=10'}
+
   define-data-property@1.1.4:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
@@ -1551,9 +1891,27 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  delegates@1.0.0:
+    resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  detect-node@2.1.0:
+    resolution: {integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==}
+
+  dir-compare@4.2.0:
+    resolution: {integrity: sha512-2xMCmOoMrdQIPHdsTawECdNPwlVFB9zGcz3kuhmBO6U3oU+UQjsue0i8ayLKpgBcm+hcXPMVSGUN9d+pvJ6+VQ==}
+
+  dmg-builder@25.1.8:
+    resolution: {integrity: sha512-NoXo6Liy2heSklTI5OIZbCgXC1RzrDQsZkeEwXhdOro3FT1VBOvbubvscdPnjVuQ4AMwwv61oaH96AbiYg9EnQ==}
+
+  dmg-license@1.0.11:
+    resolution: {integrity: sha512-ZdzmqwKmECOWJpqefloC5OJy1+WZBBse5+MR88z9g9Zn4VY+WYUkAyojmhzJckH5YbbZGcYIuGAkY5/Ys5OM2Q==}
+    engines: {node: '>=8'}
+    os: [darwin]
+    hasBin: true
 
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
@@ -1572,9 +1930,20 @@ packages:
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
+  dotenv-expand@11.0.7:
+    resolution: {integrity: sha512-zIHwmZPRshsCdpMDyVsqGmgyP0yT8GAgXUnkdAoJisxvf33k7yO6OuoKmcTGuXPWSsm8Oh88nZicRLA9Y0rUeA==}
+    engines: {node: '>=12'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
+
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
@@ -1583,14 +1952,41 @@ packages:
     resolution: {integrity: sha512-UgGlf8IW75je7HZjNDpJdCv4cGJWIi6yumFdZ0R7A8/CIhQiWUjyGLCxdHpd8bmyD1gnkfUNK0oeOXqUS2cpfQ==}
     engines: {ecmascript: '>= es5', node: '>=4'}
 
+  ejs@3.1.10:
+    resolution: {integrity: sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==}
+    engines: {node: '>=0.10.0'}
+    hasBin: true
+
+  electron-builder-squirrel-windows@25.1.8:
+    resolution: {integrity: sha512-2ntkJ+9+0GFP6nAISiMabKt6eqBB0kX1QqHNWFWAXgi0VULKGisM46luRFpIBiU3u/TDmhZMM8tzvo2Abn3ayg==}
+
+  electron-builder@25.1.8:
+    resolution: {integrity: sha512-poRgAtUHHOnlzZnc9PK4nzG53xh74wj2Jy7jkTrqZ0MWPoHGh1M2+C//hGeYdA+4K8w4yiVCNYoLXF7ySj2Wig==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
+  electron-publish@25.1.7:
+    resolution: {integrity: sha512-+jbTkR9m39eDBMP4gfbqglDd6UvBC7RLh5Y0MhFSsc6UkGHj9Vj9TWobxevHYMMqmoujL11ZLjfPpMX+Pt6YEg==}
+
   electron-to-chromium@1.5.349:
     resolution: {integrity: sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==}
+
+  electron@33.4.11:
+    resolution: {integrity: sha512-xmdAs5QWRkInC7TpXGNvzo/7exojubk+72jn1oJL7keNeIlw7xNglf8TGtJtkR4rWC5FJq0oXiIXPS9BcK2Irg==}
+    engines: {node: '>= 12.20.55'}
+    hasBin: true
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
   encoding-sniffer@0.2.1:
     resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
+  encoding@0.1.13:
+    resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
 
   end-of-stream@1.4.5:
     resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
@@ -1607,9 +2003,16 @@ packages:
     resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
     engines: {node: '>=0.12'}
 
+  env-paths@2.2.1:
+    resolution: {integrity: sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==}
+    engines: {node: '>=6'}
+
   environment@1.1.0:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
+
+  err-code@2.0.3:
+    resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -1645,6 +2048,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es6-error@4.1.1:
+    resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -1749,9 +2155,21 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  exponential-backoff@3.1.3:
+    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
+
+  extract-zip@2.0.1:
+    resolution: {integrity: sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==}
+    engines: {node: '>= 10.17.0'}
+    hasBin: true
+
+  extsprintf@1.4.1:
+    resolution: {integrity: sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==}
+    engines: {'0': node >=0.6.0}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1772,6 +2190,9 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1784,6 +2205,9 @@ packages:
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
+
+  filelist@1.0.6:
+    resolution: {integrity: sha512-5giy2PkLYY1cP39p17Ech+2xlpTRL9HLspOfEgm0L6CwBXBTgsK5ou0JtzYuepxkaQ/tvhCFIJ5uXo0OrM2DxA==}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -1815,9 +2239,28 @@ packages:
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
 
+  fs-extra@10.1.0:
+    resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
+    engines: {node: '>=12'}
+
   fs-extra@11.3.5:
     resolution: {integrity: sha512-eKpRKAovdpZtR1WopLHxlBWvAgPny3c4gX1G5Jhwmmw4XJj0ifSD5qB5TOo8hmA0wlRKDAOAhEE1yVPgs6Fgcg==}
     engines: {node: '>=14.14'}
+
+  fs-extra@8.1.0:
+    resolution: {integrity: sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==}
+    engines: {node: '>=6 <7 || >=8'}
+
+  fs-extra@9.1.0:
+    resolution: {integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==}
+    engines: {node: '>=10'}
+
+  fs-minipass@2.1.0:
+    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
+    engines: {node: '>= 8'}
+
+  fs.realpath@1.0.0:
+    resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1834,6 +2277,11 @@ packages:
   functions-have-names@1.2.3:
     resolution: {integrity: sha512-xckBUXyTIqT97tq2x2AMb+g163b5JFysYk0x4qxNFwbfQkmNZoiRHb6sPzI9/QV33WeuvVYBUIiD4NzNIyqaRQ==}
 
+  gauge@4.0.4:
+    resolution: {integrity: sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
+
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
     engines: {node: '>= 0.4'}
@@ -1842,6 +2290,10 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -1849,6 +2301,10 @@ packages:
   get-proto@1.0.1:
     resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
     engines: {node: '>= 0.4'}
+
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
 
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
@@ -1865,11 +2321,29 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
     deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
+
+  glob@7.2.3:
+    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  glob@8.1.0:
+    resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
+    engines: {node: '>=12'}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  global-agent@3.0.0:
+    resolution: {integrity: sha512-PT6XReJ+D07JvGoxQMkT6qji/jVNfX/h364XHZOWeRzy64sSFr+xJ5OX7LI3b4MPQzdL4H8Y8M0xzPpsVMwA8Q==}
+    engines: {node: '>=10.0'}
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -1890,6 +2364,10 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  got@11.8.6:
+    resolution: {integrity: sha512-6tfZ91bOr7bOXnK7PRDCGBLa1H4U080YHNaAQ2KsMGlLEzRbk44nsZF2E1IeRc3vtJHPVbKCYgdFbaGO2ljd8g==}
+    engines: {node: '>=10.19.0'}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -1921,6 +2399,9 @@ packages:
     resolution: {integrity: sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==}
     engines: {node: '>= 0.4'}
 
+  has-unicode@2.0.1:
+    resolution: {integrity: sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==}
+
   hasown@2.0.3:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
@@ -1936,13 +2417,36 @@ packages:
   htmlparser2@10.1.0:
     resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
 
+  http-cache-semantics@4.2.0:
+    resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-proxy-agent@5.0.0:
+    resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
+    engines: {node: '>= 6'}
+
   http-proxy-agent@7.0.2:
     resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
     engines: {node: '>= 14'}
 
+  http2-wrapper@1.0.3:
+    resolution: {integrity: sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==}
+    engines: {node: '>=10.19.0'}
+
+  https-proxy-agent@5.0.1:
+    resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
+    engines: {node: '>= 6'}
+
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  humanize-ms@1.2.1:
+    resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
+
+  iconv-corefoundation@1.1.7:
+    resolution: {integrity: sha512-T10qvkw0zz4wnm560lOEg0PovVqUXuOFhhHAkixw8/sycy7TJt7v/RrkEKEQnAw2viPSJu6iAkErxnzR0g8PpQ==}
+    engines: {node: ^8.11.2 || >=10}
+    os: [darwin]
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
@@ -1967,9 +2471,20 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   index-to-position@1.2.0:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
+
+  infer-owner@1.0.4:
+    resolution: {integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==}
+
+  inflight@1.0.6:
+    resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
@@ -1980,6 +2495,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -2000,6 +2519,10 @@ packages:
   is-callable@1.2.7:
     resolution: {integrity: sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==}
     engines: {node: '>= 0.4'}
+
+  is-ci@3.0.1:
+    resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
+    hasBin: true
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -2047,6 +2570,13 @@ packages:
     engines: {node: '>=14.16'}
     hasBin: true
 
+  is-interactive@1.0.0:
+    resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
+    engines: {node: '>=8'}
+
+  is-lambda@1.0.1:
+    resolution: {integrity: sha512-z7CMFGNrENq5iFB9Bqo64Xk6Y9sg+epq1myIcdHaGnbMTYOxvzsEtdYqQUylB7LxfkvgrrjP32T6Ywciio9UIQ==}
+
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
@@ -2087,6 +2617,10 @@ packages:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
 
+  is-unicode-supported@0.1.0:
+    resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
+    engines: {node: '>=10'}
+
   is-weakmap@2.0.2:
     resolution: {integrity: sha512-K5pXYOm9wqY1RgjpL3YTkF39tni1XajUIkawTLUo9EZEVUFga5gSQJF8nNS7ZwJQ02y+1YCNYcMh+HIf1ZqE+w==}
     engines: {node: '>= 0.4'}
@@ -2103,8 +2637,19 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  isarray@1.0.0:
+    resolution: {integrity: sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==}
+
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
+
+  isbinaryfile@4.0.10:
+    resolution: {integrity: sha512-iHrqe5shvBUcFbmZq9zOQHBoeOhZJu6RQGrDpBgenUm/Am+F3JM2MgQj+rK3Z601fzrL5gLZWtAPH2OBaSVcyw==}
+    engines: {node: '>= 8.0.0'}
+
+  isbinaryfile@5.0.7:
+    resolution: {integrity: sha512-gnWD14Jh3FzS3CPhF0AxNOJ8CxqeblPTADzI38r0wt8ZyQl5edpy75myt08EG2oKvpyiqSqsx+Wkz9vtkbTqYQ==}
+    engines: {node: '>= 18.0.0'}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -2117,9 +2662,17 @@ packages:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
     engines: {node: '>= 0.4'}
 
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jackspeak@4.2.3:
     resolution: {integrity: sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==}
     engines: {node: 20 || >=22}
+
+  jake@10.9.4:
+    resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2149,6 +2702,9 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stringify-safe@5.0.1:
+    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -2156,6 +2712,9 @@ packages:
 
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  jsonfile@4.0.0:
+    resolution: {integrity: sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==}
 
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
@@ -2184,6 +2743,13 @@ packages:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
 
+  lazy-val@1.0.5:
+    resolution: {integrity: sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==}
+
+  lazystream@1.0.1:
+    resolution: {integrity: sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==}
+    engines: {node: '>= 0.6.3'}
+
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
     engines: {node: '>=6'}
@@ -2198,6 +2764,15 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.difference@4.5.0:
+    resolution: {integrity: sha512-dS2j+W26TQ7taQBGN8Lbbq04ssV3emRw4NY58WErlTO29pIqS0HmoT5aJ9+TUQ1N3G+JOZSji4eugsWwGp9yPA==}
+
+  lodash.flatten@4.4.0:
+    resolution: {integrity: sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==}
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -2226,8 +2801,15 @@ packages:
   lodash.truncate@4.4.2:
     resolution: {integrity: sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==}
 
+  lodash.union@4.6.0:
+    resolution: {integrity: sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==}
+
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  log-symbols@4.1.0:
+    resolution: {integrity: sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==}
+    engines: {node: '>=10'}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -2235,6 +2817,10 @@ packages:
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lowercase-keys@2.0.0:
+    resolution: {integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==}
+    engines: {node: '>=8'}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -2250,6 +2836,10 @@ packages:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
 
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+
   lucide-react@1.14.0:
     resolution: {integrity: sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==}
     peerDependencies:
@@ -2258,9 +2848,17 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  make-fetch-happen@10.2.1:
+    resolution: {integrity: sha512-NgOPbRiaQM10DYXvN3/hhGVI2M5MtITFryzBGxHM5p4wnFxsVCbxkrBrDsk+EZ5OB4jEOT7AjDxtdF+KVEFT7w==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
   markdown-it@14.2.0:
     resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
     hasBin: true
+
+  matcher@3.0.0:
+    resolution: {integrity: sha512-OkeDaAZ/bQCxeFAozM55PKcKU0yJMPGifLwV4Qgjitu+5MoAfSQN4lsLJeXZ1b8w0x+/Emda6MZgXS1jvsapng==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2290,6 +2888,19 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  mime@2.6.0:
+    resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
+  mimic-response@1.0.1:
+    resolution: {integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==}
+    engines: {node: '>=4'}
+
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -2301,15 +2912,60 @@ packages:
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
 
+  minimatch@5.1.9:
+    resolution: {integrity: sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==}
+    engines: {node: '>=10'}
+
+  minimatch@9.0.9:
+    resolution: {integrity: sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass-collect@1.0.2:
+    resolution: {integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==}
+    engines: {node: '>= 8'}
+
+  minipass-fetch@2.1.2:
+    resolution: {integrity: sha512-LT49Zi2/WMROHYoqGgdlQIZh8mLPZmOrN2NdJjMXxYe4nkN6FUyuPuOAOedNJDrx0IRGg9+4guZewtp8hE6TxA==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  minipass-flush@1.0.7:
+    resolution: {integrity: sha512-TbqTz9cUwWyHS2Dy89P3ocAGUGxKjjLuR9z8w4WUTGAVgEj17/4nhgo2Du56i0Fm3Pm30g4iA8Lcqctc76jCzA==}
+    engines: {node: '>= 8'}
+
+  minipass-pipeline@1.2.4:
+    resolution: {integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==}
+    engines: {node: '>=8'}
+
+  minipass-sized@1.0.3:
+    resolution: {integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==}
+    engines: {node: '>=8'}
+
+  minipass@3.3.6:
+    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
+    engines: {node: '>=8'}
+
+  minipass@5.0.0:
+    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
+    engines: {node: '>=8'}
 
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
+  minizlib@2.1.2:
+    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
+    engines: {node: '>= 8'}
+
   mkdirp-classic@0.5.3:
     resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2328,16 +2984,31 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@0.6.4:
+    resolution: {integrity: sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==}
+    engines: {node: '>= 0.6'}
+
   node-abi@3.92.0:
     resolution: {integrity: sha512-KdHvFWZjEKDf0cakgFjebl371GPsISX2oZHcuyKqM7DtogIsHrqKeLTo8wBHxaXRAQlY2PsPlZmfo+9ZCxEREQ==}
     engines: {node: '>=10'}
 
+  node-addon-api@1.7.2:
+    resolution: {integrity: sha512-ibPK3iA+vaY1eEjESkQkM0BbCqFOaZMiXRTtdB0u7b4djtY6JnsjvPdUHVMg6xQt3B8fpTTWHI9A+ADjM9frzg==}
+
   node-addon-api@4.3.0:
     resolution: {integrity: sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==}
+
+  node-api-version@0.2.1:
+    resolution: {integrity: sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q==}
 
   node-exports-info@1.6.0:
     resolution: {integrity: sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw==}
     engines: {node: '>= 0.4'}
+
+  node-gyp@9.4.1:
+    resolution: {integrity: sha512-OQkWKbjQKbGkMf/xqI1jjy3oCTgMKJac58G2+bjZb3fza6gW2YrCSdMQYaoTb70crvE//Gngr4f0AgVHmqHvBQ==}
+    engines: {node: ^12.13 || ^14.13 || >=16}
+    hasBin: true
 
   node-releases@2.0.38:
     resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
@@ -2346,9 +3017,27 @@ packages:
     resolution: {integrity: sha512-tGnJW6OKRii9u/b2WiUViTJS+h7Apxx17qsMUjsUeNDiMMX5ZFf8F8Fcz7PAQ6omvOxHZtvDTmOYKJQwmfpjeg==}
     engines: {node: '>=20'}
 
+  nopt@6.0.0:
+    resolution: {integrity: sha512-ZwLpbTgdhuZUnZzjd7nb1ZV+4DoiC6/sfiVKok72ym/4Tlf+DFdlHYmT2JPmcNNWV6Pi3SDf1kT+A4r9RTuT9g==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    hasBin: true
+
   normalize-package-data@6.0.2:
     resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
     engines: {node: ^16.14.0 || >=18.0.0}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  normalize-url@6.1.0:
+    resolution: {integrity: sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==}
+    engines: {node: '>=10'}
+
+  npmlog@6.0.2:
+    resolution: {integrity: sha512-/vBvz5Jfr9dT/aFWd0FIRf+T/Q2WBsLENygUaFUqstqsycmZAP/t5BvFJTK0viFmSUxiUKTUplWy5vt+rvKIxg==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+    deprecated: This package is no longer supported.
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
@@ -2384,6 +3073,10 @@ packages:
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
   open@10.2.0:
     resolution: {integrity: sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA==}
     engines: {node: '>=18'}
@@ -2392,9 +3085,17 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  ora@5.4.1:
+    resolution: {integrity: sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==}
+    engines: {node: '>=10'}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
+
+  p-cancelable@2.1.1:
+    resolution: {integrity: sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==}
+    engines: {node: '>=8'}
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -2402,6 +3103,10 @@ packages:
 
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
+    engines: {node: '>=10'}
+
+  p-map@4.0.0:
+    resolution: {integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==}
     engines: {node: '>=10'}
 
   p-map@7.0.4:
@@ -2435,12 +3140,20 @@ packages:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
 
+  path-is-absolute@1.0.1:
+    resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
+    engines: {node: '>=0.10.0'}
+
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
@@ -2457,6 +3170,10 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pe-library@0.4.1:
+    resolution: {integrity: sha512-eRWB5LBz7PpDu4PUlwT0PhnQfTQJlDDdPa35urV4Osrm0t0AqQFGn+UIkU3klZvwJ8KPO3VbBFsXquA6p6kqZw==}
+    engines: {node: '>=12', npm: '>=6'}
+
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
@@ -2470,6 +3187,10 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  plist@3.1.1:
+    resolution: {integrity: sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==}
+    engines: {node: '>=10.4.0'}
 
   pluralize@2.0.0:
     resolution: {integrity: sha512-TqNZzQCD4S42De9IfnnBvILN7HAW7riLqsCyp8lgjXeysyPlX5HhqKAcJHHHb9XskE4/a+7VGC9zzx8Ls0jOAw==}
@@ -2501,6 +3222,25 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  process-nextick-args@2.0.1:
+    resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
+
+  progress@2.0.3:
+    resolution: {integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==}
+    engines: {node: '>=0.4.0'}
+
+  promise-inflight@1.0.1:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+
+  promise-retry@2.0.1:
+    resolution: {integrity: sha512-y+WKFlBR8BGXnsNlIHFGPZmyDf3DFMoLhaflAnyZgV6rG6xu+JwesTo2Q9R6XwYmtmwAFCkAk3e35jEdoeh/3g==}
+    engines: {node: '>=10'}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
@@ -2521,6 +3261,10 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-lru@5.1.1:
+    resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
+    engines: {node: '>=10'}
 
   rc-config-loader@4.1.4:
     resolution: {integrity: sha512-3GiwEzklkbXTDp52UR5nT8iXgYAx1V9ZG/kDZT7p60u2GCv2XTwQq4NzinMoMpNtXhmt3WkhYXcj6HH8HdwCEQ==}
@@ -2545,6 +3289,10 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
+  read-binary-file-arch@1.0.6:
+    resolution: {integrity: sha512-BNg9EN3DD3GsDXX7Aa8O4p92sryjkmzYYgmgTAc6CA4uGLEDzFfxOxugu21akOxpcXHiEgsYkC6nPsQvLLLmEg==}
+    hasBin: true
+
   read-pkg@9.0.1:
     resolution: {integrity: sha512-9viLL4/n1BJUCT1NXVTdS1jtm80yDEgR5T4yCelII49Mbj0v1rZdKqj7zCiYdbB0CuCgdrvHcNogAKTFPBocFA==}
     engines: {node: '>=18'}
@@ -2553,9 +3301,15 @@ packages:
     resolution: {integrity: sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==}
     engines: {node: '>=0.8'}
 
+  readable-stream@2.3.8:
+    resolution: {integrity: sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==}
+
   readable-stream@3.6.2:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
+
+  readdir-glob@1.1.3:
+    resolution: {integrity: sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==}
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -2565,9 +3319,20 @@ packages:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  resedit@1.7.2:
+    resolution: {integrity: sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==}
+    engines: {node: '>=12', npm: '>=6'}
+
+  resolve-alpn@1.2.1:
+    resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2578,9 +3343,29 @@ packages:
     engines: {node: '>= 0.4'}
     hasBin: true
 
+  responselike@2.0.1:
+    resolution: {integrity: sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==}
+
+  restore-cursor@3.1.0:
+    resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
+    engines: {node: '>=8'}
+
+  retry@0.12.0:
+    resolution: {integrity: sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==}
+    engines: {node: '>= 4'}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rimraf@3.0.2:
+    resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
+    deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  roarr@2.15.4:
+    resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
+    engines: {node: '>=8.0'}
 
   rollup@4.60.3:
     resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
@@ -2598,6 +3383,9 @@ packages:
     resolution: {integrity: sha512-wtZlHyOje6OZTGqAoaDKxFkgRtkF9CnHAVnCHKfuj200wAgL+bSJhdsCD2l0Qx/2ekEXjPWcyKkfGb5CPboslg==}
     engines: {node: '>=0.4'}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
@@ -2611,6 +3399,9 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sanitize-filename@1.6.4:
+    resolution: {integrity: sha512-9ZyI08PsvdQl2r/bBIGubpVdR3RR9sY6RDiWFPreA21C/EFlQhmgo20UZlNjZMMZNubusLhAQozkA0Od5J21Eg==}
 
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
@@ -2628,6 +3419,9 @@ packages:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
     engines: {node: '>=4'}
 
+  semver-compare@1.0.0:
+    resolution: {integrity: sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow==}
+
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
     hasBin: true
@@ -2640,6 +3434,13 @@ packages:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  serialize-error@7.0.1:
+    resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
+    engines: {node: '>=10'}
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
 
   set-function-length@1.2.2:
     resolution: {integrity: sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==}
@@ -2680,6 +3481,9 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2690,16 +3494,43 @@ packages:
   simple-get@4.0.1:
     resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
 
+  simple-update-notifier@2.0.0:
+    resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
+    engines: {node: '>=10'}
+
   slash@5.1.0:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
+
+  slice-ansi@3.0.0:
+    resolution: {integrity: sha512-pSyv7bSTC7ig9Dcgbw9AuRNUb5k5V6oDudjZoMBSr13qpLBG7tB+zgCkARjq7xIUgdz5P1Qe8u+rSGdouOOIyQ==}
+    engines: {node: '>=8'}
 
   slice-ansi@4.0.0:
     resolution: {integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==}
     engines: {node: '>=10'}
 
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  socks-proxy-agent@7.0.0:
+    resolution: {integrity: sha512-Fgl0YPZ902wEsAyiQ+idGd1A7rSFx/ayC1CQVMw5P+EQx2V0SgpGtf6OKFhVjPflPUl9YMmEOnmfjCdMUsygww==}
+    engines: {node: '>= 10'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   spdx-correct@3.2.0:
@@ -2717,8 +3548,19 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
+  sprintf-js@1.1.3:
+    resolution: {integrity: sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==}
+
+  ssri@9.0.1:
+    resolution: {integrity: sha512-o57Wcn66jMQvfHG1FlYbWeZWW/dHZhJXjpIcTfXldXEk5nz5lStPo3mK0OJQfGR3RbZUlbISexbljkJzuEj/8Q==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  stat-mode@1.0.0:
+    resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
+    engines: {node: '>= 6'}
 
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
@@ -2730,6 +3572,10 @@ packages:
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
     engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
 
   string.prototype.matchall@4.0.12:
     resolution: {integrity: sha512-6CC9uyBL+/48dYizRf7H7VAYCMCNTBeM78x/VTUe9bFEaxBepPJDa1Ow99LqI/1yF7kuy7Q3cQsYMrcjGUcskA==}
@@ -2749,6 +3595,9 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  string_decoder@1.1.1:
+    resolution: {integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==}
 
   string_decoder@1.3.0:
     resolution: {integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==}
@@ -2776,6 +3625,10 @@ packages:
   structured-source@4.0.0:
     resolution: {integrity: sha512-qGzRFNJDjFieQkl/sVOI2dUjHKRyL9dAJi2gCPGJLbJHBIkyOHxjuocpIEfbLioX+qSJpvbYdT49/YCdMznKxA==}
 
+  sumchecker@3.0.1:
+    resolution: {integrity: sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==}
+    engines: {node: '>= 8.0'}
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -2798,6 +3651,14 @@ packages:
   tar-stream@2.2.0:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
+
+  tar@6.2.1:
+    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
+    engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  temp-file@3.4.0:
+    resolution: {integrity: sha512-C5tjlC/HCtVUOi3KWVokd4vHVViOmGjtLwIh4MuzPo/nMYTV/p1urt3RnMz2IWXDdKEGJH3k5+KPxtqRsUYGtg==}
 
   terminal-link@4.0.0:
     resolution: {integrity: sha512-lk+vH+MccxNqgVqSnkMVKx4VLJfnLjDBGzH16JVZjKE2DoxP57s6/vt6JmXV5I3jBcfGrxNrYtC+mPtU7WJztA==}
@@ -2832,6 +3693,9 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  tmp-promise@3.0.3:
+    resolution: {integrity: sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==}
+
   tmp@0.2.7:
     resolution: {integrity: sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==}
     engines: {node: '>=14.14'}
@@ -2839,6 +3703,9 @@ packages:
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  truncate-utf8-bytes@1.0.2:
+    resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -2859,6 +3726,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@0.13.1:
+    resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
+    engines: {node: '>=10'}
 
   type-fest@4.41.0:
     resolution: {integrity: sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==}
@@ -2920,6 +3791,18 @@ packages:
     resolution: {integrity: sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==}
     engines: {node: '>=18'}
 
+  unique-filename@2.0.1:
+    resolution: {integrity: sha512-ODWHtkkdx3IAR+veKxFV+VBkUMcN+FaqzUUd7IZzt+0zhDZFPFxhlqwPF3YQvMHx1TD0tdgYl+kuPnJ8E6ql7A==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  unique-slug@3.0.0:
+    resolution: {integrity: sha512-8EyMynh679x/0gqE9fT9oilG+qEt+ibFyqjuVTsZn1+CMxH+XLlpvr2UZx4nVcCwTpx81nICr2JQFkM+HPLq4w==}
+    engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
+
+  universalify@0.1.2:
+    resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
+    engines: {node: '>= 4.0.0'}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -2936,11 +3819,18 @@ packages:
   url-join@4.0.1:
     resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
 
+  utf8-byte-length@1.0.5:
+    resolution: {integrity: sha512-Xn0w3MtiQ6zoz2vFyUVruaCL53O/DwUvkEeOvj+uulMm0BkUGYWmBYVyElqZaSLhY6ZD0ulfU3aBra2aVT4xfA==}
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  verror@1.10.1:
+    resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
+    engines: {node: '>=0.6.0'}
 
   version-range@4.15.0:
     resolution: {integrity: sha512-Ck0EJbAGxHwprkzFO966t4/5QkRuzh+/I1RxhLgUKKwEn+Cd8NwM60mE3AqBZg5gYODoXW0EFsQvbZjRlvdqbg==}
@@ -3047,6 +3937,9 @@ packages:
       jsdom:
         optional: true
 
+  wcwidth@1.0.1:
+    resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
+
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
@@ -3082,9 +3975,20 @@ packages:
     engines: {node: '>=8'}
     hasBin: true
 
+  wide-align@1.1.5:
+    resolution: {integrity: sha512-eDMORYaPNZ4sQIuuYPDHdQvf4gyCF9rEEV/yPxGfwPkRodwEgiMUUXTx/dex+Me0wxx53S+NgUHaP7y3MGlDmg==}
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -3101,11 +4005,30 @@ packages:
     resolution: {integrity: sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==}
     engines: {node: '>=4.0'}
 
+  xmlbuilder@15.1.1:
+    resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
+    engines: {node: '>=8.0'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
 
   yauzl@3.3.2:
     resolution: {integrity: sha512-Md9ankxxN23wncAN8s7+Tn3Co52zLUPMtnrLAbVCnfG5d2tKBFfmygYSgXlqFgXObtzIgqkx7aNgDBpso9+4qA==}
@@ -3117,6 +4040,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zip-stream@4.1.1:
+    resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
+    engines: {node: '>= 10'}
 
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
@@ -3140,6 +4067,8 @@ packages:
         optional: true
 
 snapshots:
+
+  7zip-bin@5.2.0: {}
 
   '@azu/format-text@1.0.2': {}
 
@@ -3341,6 +4270,11 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@develar/schema-utils@2.6.5':
+    dependencies:
+      ajv: 6.15.0
+      ajv-keywords: 3.5.2(ajv@6.15.0)
+
   '@dnd-kit/accessibility@3.1.1(react@18.3.1)':
     dependencies:
       react: 18.3.1
@@ -3365,6 +4299,77 @@ snapshots:
     dependencies:
       react: 18.3.1
       tslib: 2.8.1
+
+  '@electron/asar@3.4.1':
+    dependencies:
+      commander: 5.1.0
+      glob: 7.2.3
+      minimatch: 3.1.5
+
+  '@electron/get@2.0.3':
+    dependencies:
+      debug: 4.4.3
+      env-paths: 2.2.1
+      fs-extra: 8.1.0
+      got: 11.8.6
+      progress: 2.0.3
+      semver: 6.3.1
+      sumchecker: 3.0.1
+    optionalDependencies:
+      global-agent: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@electron/notarize@2.5.0':
+    dependencies:
+      debug: 4.4.3
+      fs-extra: 9.1.0
+      promise-retry: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@electron/osx-sign@1.3.1':
+    dependencies:
+      compare-version: 0.1.2
+      debug: 4.4.3
+      fs-extra: 10.1.0
+      isbinaryfile: 4.0.10
+      minimist: 1.2.8
+      plist: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@electron/rebuild@3.6.1':
+    dependencies:
+      '@malept/cross-spawn-promise': 2.0.0
+      chalk: 4.1.2
+      debug: 4.4.3
+      detect-libc: 2.1.2
+      fs-extra: 10.1.0
+      got: 11.8.6
+      node-abi: 3.92.0
+      node-api-version: 0.2.1
+      node-gyp: 9.4.1
+      ora: 5.4.1
+      read-binary-file-arch: 1.0.6
+      semver: 7.7.4
+      tar: 6.2.1
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+
+  '@electron/universal@2.0.1':
+    dependencies:
+      '@electron/asar': 3.4.1
+      '@malept/cross-spawn-promise': 2.0.0
+      debug: 4.4.3
+      dir-compare: 4.2.0
+      fs-extra: 11.3.5
+      minimatch: 9.0.9
+      plist: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -3634,6 +4639,8 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@gar/promisify@1.1.3': {}
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -3649,6 +4656,15 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
 
   '@isaacs/cliui@9.0.0': {}
 
@@ -3671,6 +4687,19 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@malept/cross-spawn-promise@2.0.0':
+    dependencies:
+      cross-spawn: 7.0.6
+
+  '@malept/flatpak-bundler@0.4.0':
+    dependencies:
+      debug: 4.4.3
+      fs-extra: 9.1.0
+      lodash: 4.18.1
+      tmp-promise: 3.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -3682,6 +4711,19 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
+
+  '@npmcli/fs@2.1.2':
+    dependencies:
+      '@gar/promisify': 1.1.3
+      semver: 7.7.4
+
+  '@npmcli/move-file@2.0.1':
+    dependencies:
+      mkdirp: 1.0.4
+      rimraf: 3.0.2
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
 
@@ -3834,7 +4876,13 @@ snapshots:
 
   '@secretlint/types@10.2.2': {}
 
+  '@sindresorhus/is@4.6.0': {}
+
   '@sindresorhus/merge-streams@2.3.0': {}
+
+  '@szmarczak/http-timer@4.0.6':
+    dependencies:
+      defer-to-connect: 2.0.1
 
   '@textlint/ast-node-types@15.7.1': {}
 
@@ -3865,6 +4913,8 @@ snapshots:
     dependencies:
       '@textlint/ast-node-types': 15.7.1
 
+  '@tootallnate/once@2.0.1': {}
+
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.29.3
@@ -3886,17 +4936,46 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@types/cacheable-request@6.0.3':
+    dependencies:
+      '@types/http-cache-semantics': 4.2.0
+      '@types/keyv': 3.1.4
+      '@types/node': 20.19.39
+      '@types/responselike': 1.0.3
+
+  '@types/debug@4.1.13':
+    dependencies:
+      '@types/ms': 2.1.0
+
   '@types/estree@1.0.8': {}
+
+  '@types/fs-extra@9.0.13':
+    dependencies:
+      '@types/node': 20.19.39
+
+  '@types/http-cache-semantics@4.2.0': {}
 
   '@types/js-yaml@4.0.9': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/keyv@3.1.4':
+    dependencies:
+      '@types/node': 20.19.39
+
+  '@types/ms@2.1.0': {}
 
   '@types/node@20.19.39':
     dependencies:
       undici-types: 6.21.0
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/plist@3.0.5':
+    dependencies:
+      '@types/node': 20.19.39
+      xmlbuilder: 11.0.1
+    optional: true
 
   '@types/prop-types@15.7.15': {}
 
@@ -3909,9 +4988,21 @@ snapshots:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
 
+  '@types/responselike@1.0.3':
+    dependencies:
+      '@types/node': 20.19.39
+
   '@types/sarif@2.1.7': {}
 
+  '@types/verror@1.10.11':
+    optional: true
+
   '@types/vscode@1.120.0': {}
+
+  '@types/yauzl@2.10.3':
+    dependencies:
+      '@types/node': 20.19.39
+    optional: true
 
   '@typescript-eslint/eslint-plugin@8.59.2(@typescript-eslint/parser@8.59.2(eslint@9.39.4)(typescript@5.9.3))(eslint@9.39.4)(typescript@5.9.3)':
     dependencies:
@@ -4139,13 +5230,36 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@xmldom/xmldom@0.9.10': {}
+
+  abbrev@1.1.1: {}
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
 
+  agent-base@6.0.2:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   agent-base@7.1.4: {}
+
+  agentkeepalive@4.6.0:
+    dependencies:
+      humanize-ms: 1.2.1
+
+  aggregate-error@3.1.0:
+    dependencies:
+      clean-stack: 2.2.0
+      indent-string: 4.0.0
+
+  ajv-keywords@3.5.2(ajv@6.15.0):
+    dependencies:
+      ajv: 6.15.0
 
   ajv@6.15.0:
     dependencies:
@@ -4172,6 +5286,93 @@ snapshots:
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
+
+  app-builder-bin@5.0.0-alpha.10: {}
+
+  app-builder-lib@25.1.8(dmg-builder@25.1.8)(electron-builder-squirrel-windows@25.1.8):
+    dependencies:
+      '@develar/schema-utils': 2.6.5
+      '@electron/notarize': 2.5.0
+      '@electron/osx-sign': 1.3.1
+      '@electron/rebuild': 3.6.1
+      '@electron/universal': 2.0.1
+      '@malept/flatpak-bundler': 0.4.0
+      '@types/fs-extra': 9.0.13
+      async-exit-hook: 2.0.1
+      bluebird-lst: 1.0.9
+      builder-util: 25.1.7
+      builder-util-runtime: 9.2.10
+      chromium-pickle-js: 0.2.0
+      config-file-ts: 0.2.8-rc1
+      debug: 4.4.3
+      dmg-builder: 25.1.8(electron-builder-squirrel-windows@25.1.8)
+      dotenv: 16.6.1
+      dotenv-expand: 11.0.7
+      ejs: 3.1.10
+      electron-builder-squirrel-windows: 25.1.8(dmg-builder@25.1.8)
+      electron-publish: 25.1.7
+      form-data: 4.0.5
+      fs-extra: 10.1.0
+      hosted-git-info: 4.1.0
+      is-ci: 3.0.1
+      isbinaryfile: 5.0.7
+      js-yaml: 4.1.1
+      json5: 2.2.3
+      lazy-val: 1.0.5
+      minimatch: 10.2.5
+      resedit: 1.7.2
+      sanitize-filename: 1.6.4
+      semver: 7.7.4
+      tar: 6.2.1
+      temp-file: 3.4.0
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+
+  aproba@2.1.0: {}
+
+  archiver-utils@2.1.0:
+    dependencies:
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      lazystream: 1.0.1
+      lodash.defaults: 4.2.0
+      lodash.difference: 4.5.0
+      lodash.flatten: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.union: 4.6.0
+      normalize-path: 3.0.0
+      readable-stream: 2.3.8
+
+  archiver-utils@3.0.4:
+    dependencies:
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      lazystream: 1.0.1
+      lodash.defaults: 4.2.0
+      lodash.difference: 4.5.0
+      lodash.flatten: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.union: 4.6.0
+      normalize-path: 3.0.0
+      readable-stream: 3.6.2
+
+  archiver@5.3.2:
+    dependencies:
+      archiver-utils: 2.1.0
+      async: 3.2.6
+      buffer-crc32: 0.2.13
+      readable-stream: 3.6.2
+      readdir-glob: 1.1.3
+      tar-stream: 2.2.0
+      zip-stream: 4.1.1
+
+  are-we-there-yet@3.0.1:
+    dependencies:
+      delegates: 1.0.0
+      readable-stream: 3.6.2
 
   argparse@1.0.10:
     dependencies:
@@ -4236,13 +5437,22 @@ snapshots:
       get-intrinsic: 1.3.0
       is-array-buffer: 3.0.5
 
+  assert-plus@1.0.0:
+    optional: true
+
   assertion-error@2.0.1: {}
 
   astral-regex@2.0.0: {}
 
+  async-exit-hook@2.0.1: {}
+
   async-function@1.0.0: {}
 
+  async@3.2.6: {}
+
   asynckit@0.4.0: {}
+
+  at-least-node@1.0.0: {}
 
   available-typed-arrays@1.0.7:
     dependencies:
@@ -4257,8 +5467,7 @@ snapshots:
 
   balanced-match@4.0.4: {}
 
-  base64-js@1.5.1:
-    optional: true
+  base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.27: {}
 
@@ -4271,9 +5480,17 @@ snapshots:
       buffer: 5.7.1
       inherits: 2.0.4
       readable-stream: 3.6.2
-    optional: true
+
+  bluebird-lst@1.0.9:
+    dependencies:
+      bluebird: 3.7.2
+
+  bluebird@3.7.2: {}
 
   boolbase@1.0.0: {}
+
+  boolean@3.2.0:
+    optional: true
 
   boundary@2.0.0: {}
 
@@ -4281,6 +5498,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
+
+  brace-expansion@2.1.1:
+    dependencies:
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.5:
     dependencies:
@@ -4302,17 +5523,81 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
+  buffer-from@1.1.2: {}
+
   buffer@5.7.1:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
-    optional: true
+
+  builder-util-runtime@9.2.10:
+    dependencies:
+      debug: 4.4.3
+      sax: 1.6.0
+    transitivePeerDependencies:
+      - supports-color
+
+  builder-util@25.1.7:
+    dependencies:
+      7zip-bin: 5.2.0
+      '@types/debug': 4.1.13
+      app-builder-bin: 5.0.0-alpha.10
+      bluebird-lst: 1.0.9
+      builder-util-runtime: 9.2.10
+      chalk: 4.1.2
+      cross-spawn: 7.0.6
+      debug: 4.4.3
+      fs-extra: 10.1.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-ci: 3.0.1
+      js-yaml: 4.1.1
+      source-map-support: 0.5.21
+      stat-mode: 1.0.0
+      temp-file: 3.4.0
+    transitivePeerDependencies:
+      - supports-color
 
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
 
   cac@6.7.14: {}
+
+  cacache@16.1.3:
+    dependencies:
+      '@npmcli/fs': 2.1.2
+      '@npmcli/move-file': 2.0.1
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      glob: 8.1.0
+      infer-owner: 1.0.4
+      lru-cache: 7.18.3
+      minipass: 3.3.6
+      minipass-collect: 1.0.2
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      mkdirp: 1.0.4
+      p-map: 4.0.0
+      promise-inflight: 1.0.1
+      rimraf: 3.0.2
+      ssri: 9.0.1
+      tar: 6.2.1
+      unique-filename: 2.0.1
+    transitivePeerDependencies:
+      - bluebird
+
+  cacheable-lookup@5.0.4: {}
+
+  cacheable-request@7.0.4:
+    dependencies:
+      clone-response: 1.0.3
+      get-stream: 5.2.0
+      http-cache-semantics: 4.2.0
+      keyv: 4.5.4
+      lowercase-keys: 2.0.0
+      normalize-url: 6.1.0
+      responselike: 2.0.1
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -4378,6 +5663,38 @@ snapshots:
   chownr@1.1.4:
     optional: true
 
+  chownr@2.0.0: {}
+
+  chromium-pickle-js@0.2.0: {}
+
+  ci-info@3.9.0: {}
+
+  clean-stack@2.2.0: {}
+
+  cli-cursor@3.1.0:
+    dependencies:
+      restore-cursor: 3.1.0
+
+  cli-spinners@2.9.2: {}
+
+  cli-truncate@2.1.0:
+    dependencies:
+      slice-ansi: 3.0.0
+      string-width: 4.2.3
+    optional: true
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+
+  clone-response@1.0.3:
+    dependencies:
+      mimic-response: 1.0.1
+
+  clone@1.0.4: {}
+
   cockatiel@3.2.1: {}
 
   color-convert@2.0.1:
@@ -4386,15 +5703,52 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  color-support@1.1.3: {}
+
   combined-stream@1.0.8:
     dependencies:
       delayed-stream: 1.0.0
 
   commander@12.1.0: {}
 
+  commander@5.1.0: {}
+
+  compare-version@0.1.2: {}
+
+  compress-commons@4.1.2:
+    dependencies:
+      buffer-crc32: 0.2.13
+      crc32-stream: 4.0.3
+      normalize-path: 3.0.0
+      readable-stream: 3.6.2
+
   concat-map@0.0.1: {}
 
+  config-file-ts@0.2.8-rc1:
+    dependencies:
+      glob: 10.5.0
+      typescript: 5.9.3
+
+  console-control-strings@1.1.0: {}
+
   convert-source-map@2.0.0: {}
+
+  core-util-is@1.0.2:
+    optional: true
+
+  core-util-is@1.0.3: {}
+
+  crc-32@1.2.2: {}
+
+  crc32-stream@4.0.3:
+    dependencies:
+      crc-32: 1.2.2
+      readable-stream: 3.6.2
+
+  crc@3.8.0:
+    dependencies:
+      buffer: 5.7.1
+    optional: true
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4439,7 +5793,6 @@ snapshots:
   decompress-response@6.0.0:
     dependencies:
       mimic-response: 3.1.0
-    optional: true
 
   deep-eql@5.0.2: {}
 
@@ -4454,6 +5807,12 @@ snapshots:
     dependencies:
       bundle-name: 4.1.0
       default-browser-id: 5.0.1
+
+  defaults@1.0.4:
+    dependencies:
+      clone: 1.0.4
+
+  defer-to-connect@2.0.1: {}
 
   define-data-property@1.1.4:
     dependencies:
@@ -4471,7 +5830,43 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  detect-libc@2.1.2:
+  delegates@1.0.0: {}
+
+  detect-libc@2.1.2: {}
+
+  detect-node@2.1.0:
+    optional: true
+
+  dir-compare@4.2.0:
+    dependencies:
+      minimatch: 3.1.5
+      p-limit: 3.1.0
+
+  dmg-builder@25.1.8(electron-builder-squirrel-windows@25.1.8):
+    dependencies:
+      app-builder-lib: 25.1.8(dmg-builder@25.1.8)(electron-builder-squirrel-windows@25.1.8)
+      builder-util: 25.1.7
+      builder-util-runtime: 9.2.10
+      fs-extra: 10.1.0
+      iconv-lite: 0.6.3
+      js-yaml: 4.1.1
+    optionalDependencies:
+      dmg-license: 1.0.11
+    transitivePeerDependencies:
+      - bluebird
+      - electron-builder-squirrel-windows
+      - supports-color
+
+  dmg-license@1.0.11:
+    dependencies:
+      '@types/plist': 3.0.5
+      '@types/verror': 1.10.11
+      ajv: 6.15.0
+      crc: 3.8.0
+      iconv-corefoundation: 1.1.7
+      plist: 3.1.1
+      smart-buffer: 4.2.0
+      verror: 1.10.1
     optional: true
 
   doctrine@2.1.0:
@@ -4496,11 +5891,19 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
+  dotenv-expand@11.0.7:
+    dependencies:
+      dotenv: 16.6.1
+
+  dotenv@16.6.1: {}
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       es-errors: 1.3.0
       gopd: 1.2.0
+
+  eastasianwidth@0.2.0: {}
 
   ecdsa-sig-formatter@1.0.11:
     dependencies:
@@ -4510,19 +5913,77 @@ snapshots:
     dependencies:
       version-range: 4.15.0
 
+  ejs@3.1.10:
+    dependencies:
+      jake: 10.9.4
+
+  electron-builder-squirrel-windows@25.1.8(dmg-builder@25.1.8):
+    dependencies:
+      app-builder-lib: 25.1.8(dmg-builder@25.1.8)(electron-builder-squirrel-windows@25.1.8)
+      archiver: 5.3.2
+      builder-util: 25.1.7
+      fs-extra: 10.1.0
+    transitivePeerDependencies:
+      - bluebird
+      - dmg-builder
+      - supports-color
+
+  electron-builder@25.1.8(electron-builder-squirrel-windows@25.1.8):
+    dependencies:
+      app-builder-lib: 25.1.8(dmg-builder@25.1.8)(electron-builder-squirrel-windows@25.1.8)
+      builder-util: 25.1.7
+      builder-util-runtime: 9.2.10
+      chalk: 4.1.2
+      dmg-builder: 25.1.8(electron-builder-squirrel-windows@25.1.8)
+      fs-extra: 10.1.0
+      is-ci: 3.0.1
+      lazy-val: 1.0.5
+      simple-update-notifier: 2.0.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - bluebird
+      - electron-builder-squirrel-windows
+      - supports-color
+
+  electron-publish@25.1.7:
+    dependencies:
+      '@types/fs-extra': 9.0.13
+      builder-util: 25.1.7
+      builder-util-runtime: 9.2.10
+      chalk: 4.1.2
+      fs-extra: 10.1.0
+      lazy-val: 1.0.5
+      mime: 2.6.0
+    transitivePeerDependencies:
+      - supports-color
+
   electron-to-chromium@1.5.349: {}
 
+  electron@33.4.11:
+    dependencies:
+      '@electron/get': 2.0.3
+      '@types/node': 20.19.39
+      extract-zip: 2.0.1
+    transitivePeerDependencies:
+      - supports-color
+
   emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   encoding-sniffer@0.2.1:
     dependencies:
       iconv-lite: 0.6.3
       whatwg-encoding: 3.1.1
 
+  encoding@0.1.13:
+    dependencies:
+      iconv-lite: 0.6.3
+    optional: true
+
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
-    optional: true
 
   entities@4.5.0: {}
 
@@ -4530,7 +5991,11 @@ snapshots:
 
   entities@7.0.1: {}
 
+  env-paths@2.2.1: {}
+
   environment@1.1.0: {}
+
+  err-code@2.0.3: {}
 
   es-abstract@1.24.2:
     dependencies:
@@ -4634,6 +6099,9 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es6-error@4.1.1:
+    optional: true
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -4831,9 +6299,24 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  exponential-backoff@3.1.3: {}
+
   extend-shallow@2.0.1:
     dependencies:
       is-extendable: 0.1.1
+
+  extract-zip@2.0.1:
+    dependencies:
+      debug: 4.4.3
+      get-stream: 5.2.0
+      yauzl: 2.10.0
+    optionalDependencies:
+      '@types/yauzl': 2.10.3
+    transitivePeerDependencies:
+      - supports-color
+
+  extsprintf@1.4.1:
+    optional: true
 
   fast-deep-equal@3.1.3: {}
 
@@ -4855,6 +6338,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -4862,6 +6349,10 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  filelist@1.0.6:
+    dependencies:
+      minimatch: 5.1.9
 
   fill-range@7.1.1:
     dependencies:
@@ -4896,14 +6387,38 @@ snapshots:
       hasown: 2.0.3
       mime-types: 2.1.35
 
-  fs-constants@1.0.0:
-    optional: true
+  fs-constants@1.0.0: {}
+
+  fs-extra@10.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
 
   fs-extra@11.3.5:
     dependencies:
       graceful-fs: 4.2.11
       jsonfile: 6.2.1
       universalify: 2.0.1
+
+  fs-extra@8.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 4.0.0
+      universalify: 0.1.2
+
+  fs-extra@9.1.0:
+    dependencies:
+      at-least-node: 1.0.0
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
+  fs-minipass@2.1.0:
+    dependencies:
+      minipass: 3.3.6
+
+  fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -4921,9 +6436,22 @@ snapshots:
 
   functions-have-names@1.2.3: {}
 
+  gauge@4.0.4:
+    dependencies:
+      aproba: 2.1.0
+      color-support: 1.1.3
+      console-control-strings: 1.1.0
+      has-unicode: 2.0.1
+      signal-exit: 3.0.7
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wide-align: 1.1.5
+
   generator-function@2.0.1: {}
 
   gensync@1.0.0-beta.2: {}
+
+  get-caller-file@2.0.5: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -4943,6 +6471,10 @@ snapshots:
       dunder-proto: 1.0.1
       es-object-atoms: 1.1.1
 
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
   get-symbol-description@1.1.0:
     dependencies:
       call-bound: 1.0.4
@@ -4960,6 +6492,15 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.9
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   glob@11.1.0:
     dependencies:
       foreground-child: 3.3.1
@@ -4968,6 +6509,33 @@ snapshots:
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 2.0.2
+
+  glob@7.2.3:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 3.1.5
+      once: 1.4.0
+      path-is-absolute: 1.0.1
+
+  glob@8.1.0:
+    dependencies:
+      fs.realpath: 1.0.0
+      inflight: 1.0.6
+      inherits: 2.0.4
+      minimatch: 5.1.9
+      once: 1.4.0
+
+  global-agent@3.0.0:
+    dependencies:
+      boolean: 3.2.0
+      es6-error: 4.1.1
+      matcher: 3.0.0
+      roarr: 2.15.4
+      semver: 7.7.4
+      serialize-error: 7.0.1
+    optional: true
 
   globals@14.0.0: {}
 
@@ -4988,6 +6556,20 @@ snapshots:
       unicorn-magic: 0.3.0
 
   gopd@1.2.0: {}
+
+  got@11.8.6:
+    dependencies:
+      '@sindresorhus/is': 4.6.0
+      '@szmarczak/http-timer': 4.0.6
+      '@types/cacheable-request': 6.0.3
+      '@types/responselike': 1.0.3
+      cacheable-lookup: 5.0.4
+      cacheable-request: 7.0.4
+      decompress-response: 6.0.0
+      http2-wrapper: 1.0.3
+      lowercase-keys: 2.0.0
+      p-cancelable: 2.1.1
+      responselike: 2.0.1
 
   graceful-fs@4.2.11: {}
 
@@ -5016,6 +6598,8 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
+  has-unicode@2.0.1: {}
+
   hasown@2.0.3:
     dependencies:
       function-bind: 1.1.2
@@ -5035,9 +6619,31 @@ snapshots:
       domutils: 3.2.2
       entities: 7.0.1
 
+  http-cache-semantics@4.2.0: {}
+
+  http-proxy-agent@5.0.0:
+    dependencies:
+      '@tootallnate/once': 2.0.1
+      agent-base: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  http2-wrapper@1.0.3:
+    dependencies:
+      quick-lru: 5.1.1
+      resolve-alpn: 1.2.1
+
+  https-proxy-agent@5.0.1:
+    dependencies:
+      agent-base: 6.0.2
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
@@ -5049,12 +6655,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  humanize-ms@1.2.1:
+    dependencies:
+      ms: 2.1.3
+
+  iconv-corefoundation@1.1.7:
+    dependencies:
+      cli-truncate: 2.1.0
+      node-addon-api: 1.7.2
+    optional: true
+
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
 
-  ieee754@1.2.1:
-    optional: true
+  ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
@@ -5067,10 +6682,18 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  indent-string@4.0.0: {}
+
   index-to-position@1.2.0: {}
 
-  inherits@2.0.4:
-    optional: true
+  infer-owner@1.0.4: {}
+
+  inflight@1.0.6:
+    dependencies:
+      once: 1.4.0
+      wrappy: 1.0.2
+
+  inherits@2.0.4: {}
 
   ini@1.3.8:
     optional: true
@@ -5080,6 +6703,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.3
       side-channel: 1.1.0
+
+  ip-address@10.2.0: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -5105,6 +6730,10 @@ snapshots:
       has-tostringtag: 1.0.2
 
   is-callable@1.2.7: {}
+
+  is-ci@3.0.1:
+    dependencies:
+      ci-info: 3.9.0
 
   is-core-module@2.16.1:
     dependencies:
@@ -5149,6 +6778,10 @@ snapshots:
     dependencies:
       is-docker: 3.0.0
 
+  is-interactive@1.0.0: {}
+
+  is-lambda@1.0.1: {}
+
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
@@ -5188,6 +6821,8 @@ snapshots:
     dependencies:
       which-typed-array: 1.1.20
 
+  is-unicode-supported@0.1.0: {}
+
   is-weakmap@2.0.2: {}
 
   is-weakref@1.1.1:
@@ -5203,7 +6838,13 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
+  isarray@1.0.0: {}
+
   isarray@2.0.5: {}
+
+  isbinaryfile@4.0.10: {}
+
+  isbinaryfile@5.0.7: {}
 
   isexe@2.0.0: {}
 
@@ -5222,9 +6863,21 @@ snapshots:
       has-symbols: 1.1.0
       set-function-name: 2.0.2
 
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jackspeak@4.2.3:
     dependencies:
       '@isaacs/cliui': 9.0.0
+
+  jake@10.9.4:
+    dependencies:
+      async: 3.2.6
+      filelist: 1.0.6
+      picocolors: 1.1.1
 
   js-tokens@4.0.0: {}
 
@@ -5247,9 +6900,16 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stringify-safe@5.0.1:
+    optional: true
+
   json5@2.2.3: {}
 
   jsonc-parser@3.3.1: {}
+
+  jsonfile@4.0.0:
+    optionalDependencies:
+      graceful-fs: 4.2.11
 
   jsonfile@6.2.1:
     dependencies:
@@ -5300,6 +6960,12 @@ snapshots:
 
   kind-of@6.0.3: {}
 
+  lazy-val@1.0.5: {}
+
+  lazystream@1.0.1:
+    dependencies:
+      readable-stream: 2.3.8
+
   leven@3.1.0: {}
 
   levn@0.4.1:
@@ -5314,6 +6980,12 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash.defaults@4.2.0: {}
+
+  lodash.difference@4.5.0: {}
+
+  lodash.flatten@4.4.0: {}
 
   lodash.includes@4.3.0: {}
 
@@ -5333,13 +7005,22 @@ snapshots:
 
   lodash.truncate@4.4.2: {}
 
+  lodash.union@4.6.0: {}
+
   lodash@4.18.1: {}
+
+  log-symbols@4.1.0:
+    dependencies:
+      chalk: 4.1.2
+      is-unicode-supported: 0.1.0
 
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
 
   loupe@3.2.1: {}
+
+  lowercase-keys@2.0.0: {}
 
   lru-cache@10.4.3: {}
 
@@ -5353,6 +7034,8 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
+  lru-cache@7.18.3: {}
+
   lucide-react@1.14.0(react@18.3.1):
     dependencies:
       react: 18.3.1
@@ -5360,6 +7043,28 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  make-fetch-happen@10.2.1:
+    dependencies:
+      agentkeepalive: 4.6.0
+      cacache: 16.1.3
+      http-cache-semantics: 4.2.0
+      http-proxy-agent: 5.0.0
+      https-proxy-agent: 5.0.1
+      is-lambda: 1.0.1
+      lru-cache: 7.18.3
+      minipass: 3.3.6
+      minipass-collect: 1.0.2
+      minipass-fetch: 2.1.2
+      minipass-flush: 1.0.7
+      minipass-pipeline: 1.2.4
+      negotiator: 0.6.4
+      promise-retry: 2.0.1
+      socks-proxy-agent: 7.0.0
+      ssri: 9.0.1
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
 
   markdown-it@14.2.0:
     dependencies:
@@ -5369,6 +7074,11 @@ snapshots:
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
+
+  matcher@3.0.0:
+    dependencies:
+      escape-string-regexp: 4.0.0
+    optional: true
 
   math-intrinsics@1.1.0: {}
 
@@ -5389,8 +7099,13 @@ snapshots:
 
   mime@1.6.0: {}
 
-  mimic-response@3.1.0:
-    optional: true
+  mime@2.6.0: {}
+
+  mimic-fn@2.1.0: {}
+
+  mimic-response@1.0.1: {}
+
+  mimic-response@3.1.0: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -5400,13 +7115,57 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.14
 
-  minimist@1.2.8:
-    optional: true
+  minimatch@5.1.9:
+    dependencies:
+      brace-expansion: 2.1.1
+
+  minimatch@9.0.9:
+    dependencies:
+      brace-expansion: 2.1.1
+
+  minimist@1.2.8: {}
+
+  minipass-collect@1.0.2:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-fetch@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      minipass-sized: 1.0.3
+      minizlib: 2.1.2
+    optionalDependencies:
+      encoding: 0.1.13
+
+  minipass-flush@1.0.7:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-pipeline@1.2.4:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass-sized@1.0.3:
+    dependencies:
+      minipass: 3.3.6
+
+  minipass@3.3.6:
+    dependencies:
+      yallist: 4.0.0
+
+  minipass@5.0.0: {}
 
   minipass@7.1.3: {}
 
+  minizlib@2.1.2:
+    dependencies:
+      minipass: 3.3.6
+      yallist: 4.0.0
+
   mkdirp-classic@0.5.3:
     optional: true
+
+  mkdirp@1.0.4: {}
 
   ms@2.1.3: {}
 
@@ -5419,13 +7178,21 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@0.6.4: {}
+
   node-abi@3.92.0:
     dependencies:
       semver: 7.7.4
+
+  node-addon-api@1.7.2:
     optional: true
 
   node-addon-api@4.3.0:
     optional: true
+
+  node-api-version@0.2.1:
+    dependencies:
+      semver: 7.7.4
 
   node-exports-info@1.6.0:
     dependencies:
@@ -5434,6 +7201,23 @@ snapshots:
       object.entries: 1.1.9
       semver: 6.3.1
 
+  node-gyp@9.4.1:
+    dependencies:
+      env-paths: 2.2.1
+      exponential-backoff: 3.1.3
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      make-fetch-happen: 10.2.1
+      nopt: 6.0.0
+      npmlog: 6.0.2
+      rimraf: 3.0.2
+      semver: 7.7.4
+      tar: 6.2.1
+      which: 2.0.2
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
+
   node-releases@2.0.38: {}
 
   node-sarif-builder@3.4.0:
@@ -5441,11 +7225,26 @@ snapshots:
       '@types/sarif': 2.1.7
       fs-extra: 11.3.5
 
+  nopt@6.0.0:
+    dependencies:
+      abbrev: 1.1.1
+
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
       semver: 7.7.4
       validate-npm-package-license: 3.0.4
+
+  normalize-path@3.0.0: {}
+
+  normalize-url@6.1.0: {}
+
+  npmlog@6.0.2:
+    dependencies:
+      are-we-there-yet: 3.0.1
+      console-control-strings: 1.1.0
+      gauge: 4.0.4
+      set-blocking: 2.0.0
 
   nth-check@2.1.1:
     dependencies:
@@ -5490,7 +7289,10 @@ snapshots:
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
-    optional: true
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
 
   open@10.2.0:
     dependencies:
@@ -5508,11 +7310,25 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  ora@5.4.1:
+    dependencies:
+      bl: 4.1.0
+      chalk: 4.1.2
+      cli-cursor: 3.1.0
+      cli-spinners: 2.9.2
+      is-interactive: 1.0.0
+      is-unicode-supported: 0.1.0
+      log-symbols: 4.1.0
+      strip-ansi: 6.0.1
+      wcwidth: 1.0.1
+
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
+
+  p-cancelable@2.1.1: {}
 
   p-limit@3.1.0:
     dependencies:
@@ -5521,6 +7337,10 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-map@4.0.0:
+    dependencies:
+      aggregate-error: 3.1.0
 
   p-map@7.0.4: {}
 
@@ -5555,9 +7375,16 @@ snapshots:
 
   path-exists@4.0.0: {}
 
+  path-is-absolute@1.0.1: {}
+
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   path-scurry@2.0.2:
     dependencies:
@@ -5570,6 +7397,8 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  pe-library@0.4.1: {}
+
   pend@1.2.0: {}
 
   picocolors@1.1.1: {}
@@ -5577,6 +7406,12 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  plist@3.1.1:
+    dependencies:
+      '@xmldom/xmldom': 0.9.10
+      base64-js: 1.5.1
+      xmlbuilder: 15.1.1
 
   pluralize@2.0.0: {}
 
@@ -5610,6 +7445,17 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  process-nextick-args@2.0.1: {}
+
+  progress@2.0.3: {}
+
+  promise-inflight@1.0.1: {}
+
+  promise-retry@2.0.1:
+    dependencies:
+      err-code: 2.0.3
+      retry: 0.12.0
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
@@ -5620,7 +7466,6 @@ snapshots:
     dependencies:
       end-of-stream: 1.4.5
       once: 1.4.0
-    optional: true
 
   punycode.js@2.3.1: {}
 
@@ -5631,6 +7476,8 @@ snapshots:
       side-channel: 1.1.0
 
   queue-microtask@1.2.3: {}
+
+  quick-lru@5.1.1: {}
 
   rc-config-loader@4.1.4:
     dependencies:
@@ -5663,6 +7510,12 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  read-binary-file-arch@1.0.6:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   read-pkg@9.0.1:
     dependencies:
       '@types/normalize-package-data': 2.4.4
@@ -5675,12 +7528,25 @@ snapshots:
     dependencies:
       mute-stream: 0.0.8
 
+  readable-stream@2.3.8:
+    dependencies:
+      core-util-is: 1.0.3
+      inherits: 2.0.4
+      isarray: 1.0.0
+      process-nextick-args: 2.0.1
+      safe-buffer: 5.1.2
+      string_decoder: 1.1.1
+      util-deprecate: 1.0.2
+
   readable-stream@3.6.2:
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
-    optional: true
+
+  readdir-glob@1.1.3:
+    dependencies:
+      minimatch: 5.1.9
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -5702,7 +7568,15 @@ snapshots:
       gopd: 1.2.0
       set-function-name: 2.0.2
 
+  require-directory@2.1.1: {}
+
   require-from-string@2.0.2: {}
+
+  resedit@1.7.2:
+    dependencies:
+      pe-library: 0.4.1
+
+  resolve-alpn@1.2.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -5715,7 +7589,32 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
+  responselike@2.0.1:
+    dependencies:
+      lowercase-keys: 2.0.0
+
+  restore-cursor@3.1.0:
+    dependencies:
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+
+  retry@0.12.0: {}
+
   reusify@1.1.0: {}
+
+  rimraf@3.0.2:
+    dependencies:
+      glob: 7.2.3
+
+  roarr@2.15.4:
+    dependencies:
+      boolean: 3.2.0
+      detect-node: 2.1.0
+      globalthis: 1.0.4
+      json-stringify-safe: 5.0.1
+      semver-compare: 1.0.0
+      sprintf-js: 1.1.3
+    optional: true
 
   rollup@4.60.3:
     dependencies:
@@ -5762,6 +7661,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-buffer@5.1.2: {}
+
   safe-buffer@5.2.1: {}
 
   safe-push-apply@1.0.0:
@@ -5776,6 +7677,10 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  sanitize-filename@1.6.4:
+    dependencies:
+      truncate-utf8-bytes: 1.0.2
 
   sax@1.6.0: {}
 
@@ -5800,11 +7705,21 @@ snapshots:
       extend-shallow: 2.0.1
       kind-of: 6.0.3
 
+  semver-compare@1.0.0:
+    optional: true
+
   semver@5.7.2: {}
 
   semver@6.3.1: {}
 
   semver@7.7.4: {}
+
+  serialize-error@7.0.1:
+    dependencies:
+      type-fest: 0.13.1
+    optional: true
+
+  set-blocking@2.0.0: {}
 
   set-function-length@1.2.2:
     dependencies:
@@ -5864,6 +7779,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7: {}
+
   signal-exit@4.1.0: {}
 
   simple-concat@1.0.1:
@@ -5876,7 +7793,18 @@ snapshots:
       simple-concat: 1.0.1
     optional: true
 
+  simple-update-notifier@2.0.0:
+    dependencies:
+      semver: 7.7.4
+
   slash@5.1.0: {}
+
+  slice-ansi@3.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      astral-regex: 2.0.0
+      is-fullwidth-code-point: 3.0.0
+    optional: true
 
   slice-ansi@4.0.0:
     dependencies:
@@ -5884,7 +7812,29 @@ snapshots:
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
 
+  smart-buffer@4.2.0: {}
+
+  socks-proxy-agent@7.0.0:
+    dependencies:
+      agent-base: 6.0.2
+      debug: 4.4.3
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.2.0
+      smart-buffer: 4.2.0
+
   source-map-js@1.2.1: {}
+
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
 
   spdx-correct@3.2.0:
     dependencies:
@@ -5902,7 +7852,16 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
+  sprintf-js@1.1.3:
+    optional: true
+
+  ssri@9.0.1:
+    dependencies:
+      minipass: 3.3.6
+
   stackback@0.0.2: {}
+
+  stat-mode@1.0.0: {}
 
   std-env@3.10.0: {}
 
@@ -5916,6 +7875,12 @@ snapshots:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
 
   string.prototype.matchall@4.0.12:
     dependencies:
@@ -5961,10 +7926,13 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  string_decoder@1.1.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
-    optional: true
 
   strip-ansi@6.0.1:
     dependencies:
@@ -5984,6 +7952,12 @@ snapshots:
   structured-source@4.0.0:
     dependencies:
       boundary: 2.0.0
+
+  sumchecker@3.0.1:
+    dependencies:
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   supports-color@7.2.0:
     dependencies:
@@ -6019,7 +7993,20 @@ snapshots:
       fs-constants: 1.0.0
       inherits: 2.0.4
       readable-stream: 3.6.2
-    optional: true
+
+  tar@6.2.1:
+    dependencies:
+      chownr: 2.0.0
+      fs-minipass: 2.1.0
+      minipass: 5.0.0
+      minizlib: 2.1.2
+      mkdirp: 1.0.4
+      yallist: 4.0.0
+
+  temp-file@3.4.0:
+    dependencies:
+      async-exit-hook: 2.0.1
+      fs-extra: 10.1.0
 
   terminal-link@4.0.0:
     dependencies:
@@ -6047,11 +8034,19 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
+  tmp-promise@3.0.3:
+    dependencies:
+      tmp: 0.2.7
+
   tmp@0.2.7: {}
 
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  truncate-utf8-bytes@1.0.2:
+    dependencies:
+      utf8-byte-length: 1.0.5
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -6069,6 +8064,9 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@0.13.1:
+    optional: true
 
   type-fest@4.41.0: {}
 
@@ -6143,6 +8141,16 @@ snapshots:
 
   unicorn-magic@0.3.0: {}
 
+  unique-filename@2.0.1:
+    dependencies:
+      unique-slug: 3.0.0
+
+  unique-slug@3.0.0:
+    dependencies:
+      imurmurhash: 0.1.4
+
+  universalify@0.1.2: {}
+
   universalify@2.0.1: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.2):
@@ -6157,13 +8165,21 @@ snapshots:
 
   url-join@4.0.1: {}
 
-  util-deprecate@1.0.2:
-    optional: true
+  utf8-byte-length@1.0.5: {}
+
+  util-deprecate@1.0.2: {}
 
   validate-npm-package-license@3.0.4:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  verror@1.10.1:
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.4.1
+    optional: true
 
   version-range@4.15.0: {}
 
@@ -6241,6 +8257,10 @@ snapshots:
       - supports-color
       - terser
 
+  wcwidth@1.0.1:
+    dependencies:
+      defaults: 1.0.4
+
   whatwg-encoding@3.1.1:
     dependencies:
       iconv-lite: 0.6.3
@@ -6297,10 +8317,25 @@ snapshots:
       siginfo: 2.0.0
       stackback: 0.0.2
 
+  wide-align@1.1.5:
+    dependencies:
+      string-width: 4.2.3
+
   word-wrap@1.2.5: {}
 
-  wrappy@1.0.2:
-    optional: true
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
+
+  wrappy@1.0.2: {}
 
   wsl-utils@0.1.0:
     dependencies:
@@ -6313,9 +8348,30 @@ snapshots:
 
   xmlbuilder@11.0.1: {}
 
+  xmlbuilder@15.1.1: {}
+
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
 
   yauzl@3.3.2:
     dependencies:
@@ -6326,6 +8382,12 @@ snapshots:
       buffer-crc32: 0.2.13
 
   yocto-queue@0.1.0: {}
+
+  zip-stream@4.1.1:
+    dependencies:
+      archiver-utils: 3.0.4
+      compress-commons: 4.1.2
+      readable-stream: 3.6.2
 
   zod@4.4.3: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@boardown/ui':
         specifier: workspace:*
         version: link:../ui
+      lucide-react:
+        specifier: ^1.14.0
+        version: 1.14.0(react@18.3.1)
       react:
         specifier: ^18.3.1
         version: 18.3.1


### PR DESCRIPTION
## What this adds

A cross-platform **Electron desktop shell** (`packages/electron`) for boardown — macOS, Windows and Linux. It sits next to the existing `web` and `vscode` shells and **reuses `@boardown/ui` unchanged** behind an `FsAdapter` that proxies `read`/`write`/`list`/`stat` over IPC. **`packages/core` is untouched.**

The product spec already anticipated this (PRODUCT.md → "Electron (post-MVP)"): a recent-folders list on launch, an OS-native "Open Folder…" dialog, and an optional CLI argument for a specific folder. All three are here.

> PRODUCT.md still files Electron under "post-MVP / out of scope" — I left that wording as-is. Happy to update it to reflect that the shell now exists if you'd like.

## How it works

- **Main process** (`src/main`, bundled with esbuild → CJS, `electron` external — same pattern as the VS Code host): window lifecycle, native menu, the "Open Folder…" dialog, recent-folders persistence (`app.getPath('userData')`), an optional CLI folder argument, and the fs IPC handlers. Every path is resolved against the open project's `.boardown/` and guarded against `..`/absolute-path escapes.
- **Preload** (`src/main/preload.ts`): exposes a single `window.boardown` bridge via `contextBridge` (context isolation on, node integration off, sandboxed).
- **Renderer** (`src/renderer`, Vite): a persistent left **sidebar of projects** + the active board (or an empty state), mounting `@boardown/ui`'s `<App>` as-is.

The board root for a project is `<chosen folder>/.boardown/` — the same convention the VS Code shell uses for its workspace folder.

### Features
- Sidebar of recent projects (stable alphabetical order) with **open**, **remove (×)**, an **active** highlight, and a **"Needs setup"** badge for folders that don't have a `config.yaml` yet (one cheap `stat`, no board loading).
- **File → Open Folder…** (`Cmd/Ctrl+O`) and **Close Board** (`Cmd/Ctrl+Shift+W`); a lean Edit / View / Window menu via native roles (copy-paste, zoom, full screen, dev tools).
- The sidebar is **resizable** (drag the right edge; width persisted), the window **remembers its size, position, screen and maximized state** across launches, and the app **reopens the last project** you had open. Settings (theme + window + last project) are written atomically, so a force-quit can't corrupt them.
- Onboarding for a fresh folder **pre-fills** the project name (from the folder) and a derived ID prefix, and can be **cancelled** (button + ESC/backdrop) back to the sidebar.
- **Theme is an app-wide setting** (System / Light / Dark) chosen from a **Settings** control in the sidebar; it applies to every project and persists across launches, with no first-paint flash. See the note below — the per-board `config.theme` is intentionally ignored in the desktop shell.
- Optional CLI folder argument opens that board on launch.

### Shared-UI change (additive, backward-compatible)
`packages/ui` gained a few **optional** props, all unused by `web`/`vscode` (so their behaviour is unchanged): on `App` — `defaultProjectName`, `defaultIdPrefix`, `onCancel` (onboarding seeds + cancel) and `forcedTheme` (lets a host own the theme app-wide, overriding `config.theme` for display); on `TabBar` — `hideSettings` (hide the per-board theme control when the host owns the theme).

### Tooling
- `electron` added to the ESLint React glob and to the root `pnpm.onlyBuiltDependencies` (so the Electron binary downloads on `pnpm install`).

## How to use it (from sources)

```sh
pnpm install
pnpm --filter @boardown/electron dev                       # Vite HMR + esbuild watch + Electron
pnpm --filter @boardown/electron dev -- /path/to/project   # open a board on launch
```

## How to make distributable builds

```sh
pnpm --filter @boardown/electron build   # main + preload (esbuild) + renderer (Vite) → dist/
pnpm --filter @boardown/electron dist    # OS installers via electron-builder → release/
```

`electron-builder.yml` targets macOS (`dmg`/`zip`), **Windows (`zip` — no installer, unzip and run `boardown.exe`)** and Linux (`AppImage`/`deb`). `electron-builder` packages for the host OS, so a local `dist` builds for the current platform; all three need a CI matrix (one runner per OS). **Signed / notarized** artifacts (Apple notarization, Windows code-signing) need certificates/secrets and belong in that CI step — not done here.

## Theme is app-wide in the desktop shell (note for review)

In the desktop app the theme is a single **app-level** setting (sidebar → Settings: System / Light / Dark), applied to all projects and persisted in `userData/settings.json`. It's implemented with the new optional `forcedTheme` prop, so **`config.theme` is intentionally ignored for display in Electron** (it felt odd for the theme to change as you switch projects). `web` and `vscode` are unchanged — they still read/write `config.theme`.

Open question: should theme stay **per-board** (`config.theme`) or become **app-wide** everywhere? Today it's per-board except in the desktop shell — happy to align whichever way you prefer.

## Tests & checks
- 35 unit tests in the package: the path-traversal guard + fs semantics, recent-folders (add/dedup/cap/remove/prune/`hasBoard`), the folder-name / prefix helpers, and theme-setting persistence.
- `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test` all pass.

## Out of scope / possible follow-ups
- App icon / branding (currently the default Electron icon) — needs an asset.
- Signed multi-platform installers in CI.
- Updating PRODUCT.md's "post-MVP" wording, if you want.
