### PR TITLE
feat(cli): command-line / agent-facing shell

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,9 +56,15 @@ boardown/
 │   │                  # over a Vite middleware that serves a selected
 │   │                  # .boardown/, manual Reload only. Mounts @boardown/ui.
 │   │                  # No production browser deployment in MVP.
-│   └── vscode/        # Primary MVP shell: extension host (esbuild) + webview
-│                      # (Vite) hosting @boardown/ui. Built in stages; see
-│                      # PRODUCT.md roadmap.
+│   ├── vscode/        # Primary MVP shell: extension host (esbuild) + webview
+│   │                  # (Vite) hosting @boardown/ui. Built in stages; see
+│   │                  # PRODUCT.md roadmap.
+│   ├── electron/      # Desktop shell (macOS / Windows / Linux): Electron main
+│   │                  # (esbuild) + renderer (Vite) hosting @boardown/ui over a
+│   │                  # Node FsAdapter. Post-MVP.
+│   └── cli/           # Command-line / agent-facing shell: maps argv onto
+│                      # @boardown/core board-ops over a Node FsAdapter, with
+│                      # machine-readable JSON output. Post-MVP.
 ├── package.json
 ├── pnpm-workspace.yaml
 ├── tsconfig.base.json
@@ -70,8 +76,8 @@ boardown/
 `main`/`exports` point at `src/index.ts`, no separate build step. The shell's
 bundler (Vite for `web`, esbuild for the VS Code host) transpiles them, and
 `tsc`/ESLint resolve their types straight from source. Neither package emits a
-`dist/`. Only the shells (`web`, `vscode`) have a `build` script — they bundle
-the source-only libraries into their own artifacts.
+`dist/`. Only the shells (`web`, `vscode`, `electron`, `cli`) have a `build`
+script — they bundle the source-only libraries into their own artifacts.
 
 `packages/vscode` is the primary MVP distribution target, built bottom-up in
 stages (see PRODUCT.md roadmap). It is a sibling shell next to `web` and reuses
@@ -92,6 +98,15 @@ endpoints. This is the **only** browser-side path for the MVP — it is the
 working environment for `@boardown/ui` development, not a stepping stone to
 a production browser app. A production browser shell (with the FS Access
 API or otherwise) is post-MVP and may or may not happen.
+
+`packages/cli` is a post-MVP shell that does **not** mount `@boardown/ui` — it has
+no DOM. Instead it consumes `@boardown/core` directly (board-ops, loader,
+serializer, schemas) and implements `FsAdapter` over `node:fs/promises`, mapping
+CLI commands onto board operations. It is aimed at agents and scripts: output is a
+stable JSON envelope when stdout is not a TTY (or with `--json`), human-readable
+otherwise. The bin is bundled with esbuild into a single Node CJS file. Process
+invariants (release lifecycle, finished-release read-only) live in `core`, so the
+CLI inherits them rather than re-implementing them.
 
 ## Conventions
 

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -291,6 +291,18 @@ app: a recent-folders list on launch, an "Open Folder…" menu using the OS
 native dialog, and an optional CLI argument for opening a specific folder.
 Out of scope for the MVP.
 
+### CLI (post-MVP)
+
+A headless shell that does not mount `@boardown/ui` — it consumes
+`@boardown/core` directly and implements `FsAdapter` over Node's filesystem.
+It finds the board by walking up from the working directory to a `.boardown/`
+folder (or via `--data-dir`), and maps commands onto board operations
+(`board`, `task`, `release`, `epic`, `init`). It is aimed primarily at **agents
+and scripts**: output is a stable JSON envelope when stdout is not a TTY (or
+with `--json`), with stable error codes and exit codes, plus a `schema` command
+that prints the contract. Because every change is a plain-markdown git diff, an
+agent's edits stay reviewable and revertible. Out of scope for the MVP.
+
 ## Lenient parsing
 
 - A broken file does not block other files.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,65 @@
+# @boardown/cli
+
+A command-line and **agent-facing** interface for [boardown](../../README.md)
+task boards. It is a shell over `@boardown/core`: it implements the `FsAdapter`
+on top of Node's filesystem and maps commands onto the same board operations the
+UI uses. Because a board is just markdown files in git, every command is a
+reviewable, revertible `git diff` — which makes it a good surface for automation
+and AI agents.
+
+## Commands
+
+```
+boardown board                  Print the whole board.
+boardown init                   Create a .boardown/ board in the current directory.
+boardown task add <title>       Create a task (--type --status --epic --release --description).
+boardown task edit <id>         Edit a task (--title --description --type --status --epic --no-epic).
+boardown task status <id> <s>   Change a task status (todo | in-progress | done).
+boardown task rm <id>           Delete a task.
+boardown schema                 Print the machine-readable command/enum contract.
+```
+
+The board is located by walking up from the current directory to a `.boardown/`
+folder (like git finds `.git`). Use `--data-dir <path>` to point at a specific
+`.boardown/` directory instead.
+
+## Machine-readable output
+
+Output is JSON whenever stdout is not a TTY, or with `--json`. Every command
+emits a stable envelope:
+
+```jsonc
+{ "ok": true,  "command": "task add", "data": { /* … */ } }
+{ "ok": false, "command": "task add", "error": { "code": "EPIC_NOT_FOUND", "message": "…" } }
+```
+
+Exit codes: `0` success, `1` operation failed, `2` usage error. Run
+`boardown schema --json` for the full contract (valid task types, statuses, and
+command grammar) — agents can read it instead of guessing.
+
+## Install
+
+This package is built with esbuild into a single Node bundle (`dist/cli.cjs`).
+
+Build it, then link it onto your `PATH`:
+
+```bash
+pnpm --filter @boardown/cli build
+cd packages/cli && pnpm link --global   # or: npm link
+boardown --help
+```
+
+For a one-off local run without linking:
+
+```bash
+pnpm --filter @boardown/cli build
+node packages/cli/dist/cli.cjs board
+```
+
+## Develop
+
+```bash
+pnpm --filter @boardown/cli watch       # rebuild on change
+pnpm --filter @boardown/cli test        # vitest
+pnpm --filter @boardown/cli typecheck   # tsc --noEmit
+```

--- a/packages/cli/esbuild.mjs
+++ b/packages/cli/esbuild.mjs
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+import { chmod } from 'node:fs/promises';
+import esbuild from 'esbuild';
+
+const options = {
+  entryPoints: ['src/cli.ts'],
+  outfile: 'dist/cli.cjs',
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  target: 'node20',
+  banner: { js: '#!/usr/bin/env node' },
+  sourcemap: true,
+};
+
+if (process.argv.includes('--watch')) {
+  const ctx = await esbuild.context(options);
+  await ctx.watch();
+  console.log('[cli] watching for changes…');
+} else {
+  await esbuild.build(options);
+  await chmod(options.outfile, 0o755);
+}

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@boardown/cli",
+  "version": "0.1.0",
+  "description": "Command-line and agent-facing interface for boardown task boards.",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "boardown": "./dist/cli.cjs"
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "build": "node esbuild.mjs",
+    "watch": "node esbuild.mjs --watch",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "@boardown/core": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.10",
+    "esbuild": "^0.24.0",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/cli/src/app.ts
+++ b/packages/cli/src/app.ts
@@ -1,0 +1,110 @@
+import { parseArgs } from './args';
+import { boardCommand } from './commands/board';
+import { epicCommand } from './commands/epic';
+import { initCommand } from './commands/init';
+import { releaseCommand } from './commands/release';
+import { schemaCommand } from './commands/schema';
+import { taskCommand } from './commands/task';
+import { CliError, errEnvelope, okEnvelope } from './output';
+import type { CommandContext, CommandHandler } from './types';
+
+const COMMANDS: Record<string, CommandHandler> = {
+  board: boardCommand,
+  task: taskCommand,
+  release: releaseCommand,
+  epic: epicCommand,
+  init: initCommand,
+  schema: schemaCommand,
+};
+
+const HELP = `boardown — markdown task board CLI
+
+Usage: boardown <command> [args] [--data-dir <path>] [--json]
+
+Commands:
+  board                  Print the whole board.
+  init                   Create a .boardown/ board here.
+  task add <title>       Create a task (--type --status --epic --release --description).
+  task edit <id>         Edit a task (--title --description --type --status --epic --no-epic).
+  task status <id> <s>   Change a task status (todo | in-progress | done).
+  task move <id>         Move a task (--release | --epic | --backlog) [--status --before].
+  task rm <id>           Delete a task.
+  release add <name>     Create a release (--description).
+  release start <ref>    Make a release current.
+  release done <ref>     Finish a release (--into <release> to carry over open tasks).
+  epic add <name>        Create an epic (--color #rrggbb --description).
+  epic edit <slug>       Edit an epic (--name --description).
+  schema                 Print the machine-readable command/enum contract.
+
+Output is JSON when stdout is piped, or with --json. Run \`boardown schema\` for
+the full contract agents can branch on.`;
+
+export interface RunOptions {
+  cwd?: string;
+}
+
+export async function run(argv: readonly string[], opts: RunOptions = {}): Promise<number> {
+  const args = parseArgs(argv);
+  const command = args.positionals[0];
+  const json = args.flags.json === true || process.stdout.isTTY !== true;
+
+  if (command === undefined || command === 'help' || args.flags.help === true) {
+    if (json) {
+      process.stdout.write(
+        `${JSON.stringify({ ok: true, command: 'help', data: { commands: Object.keys(COMMANDS) } })}\n`,
+      );
+    } else {
+      process.stdout.write(`${HELP}\n`);
+    }
+    return 0;
+  }
+
+  const handler = COMMANDS[command];
+  if (handler === undefined) {
+    const err = new CliError(
+      'UNKNOWN_COMMAND',
+      `Unknown command "${command}". Try: ${Object.keys(COMMANDS).join(', ')}.`,
+      2,
+    );
+    emitError(command, err, json);
+    return err.exitCode;
+  }
+
+  const dataDir = typeof args.flags['data-dir'] === 'string' ? args.flags['data-dir'] : undefined;
+  const ctx: CommandContext = {
+    cwd: opts.cwd ?? process.cwd(),
+    json,
+    ...(dataDir !== undefined ? { dataDir } : {}),
+  };
+
+  try {
+    const out = await handler(args, ctx);
+    if (json) {
+      process.stdout.write(`${JSON.stringify(okEnvelope(command, out.data, out.problems ?? []))}\n`);
+    } else {
+      process.stdout.write(`${out.human}\n`);
+      for (const problem of out.problems ?? []) {
+        process.stderr.write(`! ${problem.file}: ${problem.message}\n`);
+      }
+    }
+    return 0;
+  } catch (err) {
+    const cliErr =
+      err instanceof CliError
+        ? err
+        : new CliError('ERROR', err instanceof Error ? err.message : String(err));
+    emitError(command, cliErr, json);
+    return cliErr.exitCode;
+  }
+}
+
+function emitError(command: string, err: CliError, json: boolean): void {
+  if (json) {
+    process.stdout.write(`${JSON.stringify(errEnvelope(command, err))}\n`);
+    return;
+  }
+  process.stderr.write(`error: ${err.message}\n`);
+  for (const problem of err.problems) {
+    process.stderr.write(`! ${problem.file}: ${problem.message}\n`);
+  }
+}

--- a/packages/cli/src/app.ts
+++ b/packages/cli/src/app.ts
@@ -24,14 +24,21 @@ Usage: boardown <command> [args] [--data-dir <path>] [--json]
 Commands:
   board                  Print the whole board.
   init                   Create a .boardown/ board here.
+  task get <id>          Show one task and where it lives.
   task add <title>       Create a task (--type --status --epic --release --description).
   task edit <id>         Edit a task (--title --description --type --status --epic --no-epic).
   task status <id> <s>   Change a task status (todo | in-progress | done).
+  task reorder <id>      Change priority (--before | --after <id> | --up | --down).
   task move <id>         Move a task (--release | --epic | --backlog) [--status --before].
   task rm <id>           Delete a task.
+  release get <ref>      Show one release and its tasks.
+  release list           List releases.
+  release current        Show the current release and its tasks.
   release add <name>     Create a release (--description).
   release start <ref>    Make a release current.
   release done <ref>     Finish a release (--into <release> to carry over open tasks).
+  epic get <slug>        Show one epic and its tasks.
+  epic list              List epics.
   epic add <name>        Create an epic (--color #rrggbb --description).
   epic edit <slug>       Edit an epic (--name --description).
   schema                 Print the machine-readable command/enum contract.

--- a/packages/cli/src/app.ts
+++ b/packages/cli/src/app.ts
@@ -26,10 +26,9 @@ Commands:
   init                   Create a .boardown/ board here.
   task get <id>          Show one task and where it lives.
   task add <title>       Create a task (--type --status --epic --release --description).
-  task edit <id>         Edit a task (--title --description --type --status --epic --no-epic).
+  task edit <id>         Edit a task; --release/--no-release also move it in/out of a release.
   task status <id> <s>   Change a task status (todo | in-progress | done).
   task reorder <id>      Change priority (--before | --after <id> | --up | --down).
-  task move <id>         Move a task (--release | --epic | --backlog) [--status --before].
   task rm <id>           Delete a task.
   release get <ref>      Show one release and its tasks.
   release list           List releases.

--- a/packages/cli/src/args.test.ts
+++ b/packages/cli/src/args.test.ts
@@ -24,6 +24,13 @@ describe('parseArgs', () => {
     expect(parseArgs(['--json', 'board']).positionals).toEqual(['board']);
   });
 
+  it('treats --up / --down / --no-release as boolean even before a positional', () => {
+    const up = parseArgs(['task', 'reorder', '--up', 'BD-1']);
+    expect(up.flags.up).toBe(true);
+    expect(up.positionals).toEqual(['task', 'reorder', 'BD-1']);
+    expect(parseArgs(['task', 'edit', '--no-release', 'BD-1']).positionals).toContain('BD-1');
+  });
+
   it('lets a value flag consume the next token but keeps later positionals', () => {
     const { positionals, flags } = parseArgs(['task', 'move', 'BD-1', '--release', 'v1', '--json']);
     expect(flags.release).toBe('v1');

--- a/packages/cli/src/args.test.ts
+++ b/packages/cli/src/args.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { flagBool, flagString, parseArgs } from './args';
+
+describe('parseArgs', () => {
+  it('collects positionals in order', () => {
+    expect(parseArgs(['task', 'add', 'My task']).positionals).toEqual(['task', 'add', 'My task']);
+  });
+
+  it('parses `--flag value`', () => {
+    expect(parseArgs(['task', 'add', 'T', '--type', 'feature']).flags.type).toBe('feature');
+  });
+
+  it('parses `--flag=value`', () => {
+    expect(parseArgs(['--data-dir=/x']).flags['data-dir']).toBe('/x');
+  });
+
+  it('treats known boolean flags as boolean', () => {
+    const { positionals, flags } = parseArgs(['board', '--json']);
+    expect(flags.json).toBe(true);
+    expect(positionals).toEqual(['board']);
+  });
+
+  it('does not let a boolean flag swallow the next token', () => {
+    expect(parseArgs(['--json', 'board']).positionals).toEqual(['board']);
+  });
+
+  it('lets a value flag consume the next token but keeps later positionals', () => {
+    const { positionals, flags } = parseArgs(['task', 'move', 'BD-1', '--release', 'v1', '--json']);
+    expect(flags.release).toBe('v1');
+    expect(flags.json).toBe(true);
+    expect(positionals).toEqual(['task', 'move', 'BD-1']);
+  });
+
+  it('flagString / flagBool read flags by name', () => {
+    const { flags } = parseArgs(['x', '--type', 'bug', '--json']);
+    expect(flagString(flags, 'type')).toBe('bug');
+    expect(flagString(flags, 'missing')).toBeUndefined();
+    expect(flagBool(flags, 'json')).toBe(true);
+    expect(flagBool(flags, 'type')).toBe(false);
+  });
+});

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -1,0 +1,54 @@
+export interface ParsedArgs {
+  positionals: string[];
+  flags: Record<string, string | boolean>;
+}
+
+// Flags that never take a value, so they don't swallow the following token
+// (e.g. `task add "T" --json` must keep "T" as a positional).
+const BOOLEAN_FLAGS = new Set(['json', 'help', 'dry-run', 'backlog', 'no-epic']);
+
+export function parseArgs(argv: readonly string[]): ParsedArgs {
+  const positionals: string[] = [];
+  const flags: Record<string, string | boolean> = {};
+
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg === undefined) continue;
+
+    if (!arg.startsWith('--')) {
+      positionals.push(arg);
+      continue;
+    }
+
+    const body = arg.slice(2);
+    const eq = body.indexOf('=');
+    if (eq !== -1) {
+      flags[body.slice(0, eq)] = body.slice(eq + 1);
+      continue;
+    }
+
+    if (BOOLEAN_FLAGS.has(body)) {
+      flags[body] = true;
+      continue;
+    }
+
+    const next = argv[i + 1];
+    if (next !== undefined && !next.startsWith('--')) {
+      flags[body] = next;
+      i++;
+    } else {
+      flags[body] = true;
+    }
+  }
+
+  return { positionals, flags };
+}
+
+export function flagString(flags: ParsedArgs['flags'], name: string): string | undefined {
+  const value = flags[name];
+  return typeof value === 'string' ? value : undefined;
+}
+
+export function flagBool(flags: ParsedArgs['flags'], name: string): boolean {
+  return flags[name] === true || flags[name] === 'true';
+}

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -5,7 +5,7 @@ export interface ParsedArgs {
 
 // Flags that never take a value, so they don't swallow the following token
 // (e.g. `task add "T" --json` must keep "T" as a positional).
-const BOOLEAN_FLAGS = new Set(['json', 'help', 'dry-run', 'backlog', 'no-epic']);
+const BOOLEAN_FLAGS = new Set(['json', 'help', 'dry-run', 'no-epic', 'no-release', 'up', 'down']);
 
 export function parseArgs(argv: readonly string[]): ParsedArgs {
   const positionals: string[] = [];

--- a/packages/cli/src/board-root.test.ts
+++ b/packages/cli/src/board-root.test.ts
@@ -1,0 +1,40 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { findBoardRoot } from './board-root';
+
+describe('findBoardRoot', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'bd-cli-root-'));
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('finds .boardown walking up from a nested directory', async () => {
+    await mkdir(join(root, '.boardown'), { recursive: true });
+    const nested = join(root, 'a', 'b', 'c');
+    await mkdir(nested, { recursive: true });
+    expect(await findBoardRoot(nested)).toBe(join(root, '.boardown'));
+  });
+
+  it('returns null when no board exists upward', async () => {
+    const nested = join(root, 'x');
+    await mkdir(nested, { recursive: true });
+    expect(await findBoardRoot(nested)).toBeNull();
+  });
+
+  it('uses an explicit dataDir when it exists', async () => {
+    const dataDir = join(root, '.boardown');
+    await mkdir(dataDir, { recursive: true });
+    expect(await findBoardRoot(root, dataDir)).toBe(dataDir);
+  });
+
+  it('returns null when an explicit dataDir is missing', async () => {
+    expect(await findBoardRoot(root, join(root, 'nope'))).toBeNull();
+  });
+});

--- a/packages/cli/src/board-root.ts
+++ b/packages/cli/src/board-root.ts
@@ -1,0 +1,35 @@
+import { access } from 'node:fs/promises';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
+
+export const BOARD_DIRNAME = '.boardown';
+
+export const pathExists = async (path: string): Promise<boolean> => {
+  try {
+    await access(path);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+// Resolve the board's `.boardown/` directory. An explicit dataDir points
+// straight at it (the web shell's `--data-dir` convention). Otherwise walk up
+// from startDir looking for `.boardown/`, the way git locates `.git`.
+export async function findBoardRoot(
+  startDir: string,
+  dataDir?: string,
+): Promise<string | null> {
+  if (dataDir !== undefined) {
+    const abs = isAbsolute(dataDir) ? dataDir : resolve(startDir, dataDir);
+    return (await pathExists(abs)) ? abs : null;
+  }
+
+  let dir = resolve(startDir);
+  for (;;) {
+    const candidate = join(dir, BOARD_DIRNAME);
+    if (await pathExists(candidate)) return candidate;
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,0 +1,12 @@
+import { run } from './app';
+
+async function main(): Promise<void> {
+  try {
+    process.exitCode = await run(process.argv.slice(2));
+  } catch (err) {
+    process.stderr.write(`fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+    process.exitCode = 1;
+  }
+}
+
+void main();

--- a/packages/cli/src/commands/board.ts
+++ b/packages/cli/src/commands/board.ts
@@ -1,0 +1,77 @@
+import type { BoardSnapshot, Release, Task } from '@boardown/core';
+import { loadBoardOrThrow, resolveBoardRoot } from '../persistence';
+import type { CommandHandler } from '../types';
+
+export const boardCommand: CommandHandler = async (_args, ctx) => {
+  const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
+  const { snapshot, problems } = await loadBoardOrThrow(root);
+  return {
+    data: {
+      config: snapshot.config,
+      releases: snapshot.releases,
+      epics: snapshot.epics,
+      backlog: snapshot.backlog,
+    },
+    human: renderBoard(snapshot),
+    ...(problems.length > 0 ? { problems } : {}),
+  };
+};
+
+const statusMark = (task: Task): string => {
+  switch (task.frontmatter.status) {
+    case 'todo':
+      return '○';
+    case 'in-progress':
+      return '◐';
+    case 'done':
+      return '●';
+  }
+};
+
+const renderTasks = (lines: string[], tasks: readonly Task[]): void => {
+  for (const task of tasks) {
+    lines.push(`  ${statusMark(task)} ${task.frontmatter.id}  ${task.title}`);
+  }
+};
+
+const renderReleases = (lines: string[], releases: readonly Release[]): void => {
+  for (const release of releases) {
+    const name = release.frontmatter.name ?? release.slug;
+    lines.push(`\n[${release.frontmatter.status}] ${name}  (${release.filename})`);
+    renderTasks(lines, release.tasks);
+  }
+};
+
+function renderBoard(snapshot: BoardSnapshot): string {
+  const lines: string[] = [`${snapshot.config.projectName} — board`];
+
+  renderReleases(
+    lines,
+    snapshot.releases.filter((r) => r.frontmatter.status === 'current'),
+  );
+  renderReleases(
+    lines,
+    snapshot.releases.filter((r) => r.frontmatter.status === 'future'),
+  );
+
+  if (snapshot.backlog && snapshot.backlog.tasks.length > 0) {
+    lines.push('\nBacklog');
+    renderTasks(lines, snapshot.backlog.tasks);
+  }
+
+  for (const epic of snapshot.epics) {
+    lines.push(`\nEpic: ${epic.frontmatter.name}  (${epic.slug})`);
+    renderTasks(lines, epic.tasks);
+  }
+
+  renderReleases(
+    lines,
+    snapshot.releases.filter((r) => r.frontmatter.status === 'finished'),
+  );
+
+  if (snapshot.problems.length > 0) {
+    lines.push(`\n${snapshot.problems.length} problem(s) — run with --json for details.`);
+  }
+
+  return lines.join('\n');
+}

--- a/packages/cli/src/commands/commands.test.ts
+++ b/packages/cli/src/commands/commands.test.ts
@@ -1,0 +1,116 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Backlog, BoardConfig, Epic, Release, Task } from '@boardown/core';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { parseArgs } from '../args';
+import { loadBoardOrThrow } from '../persistence';
+import type { CommandContext } from '../types';
+import { boardCommand } from './board';
+import { initCommand } from './init';
+import { taskCommand } from './task';
+
+interface BoardData {
+  config: BoardConfig;
+  releases: Release[];
+  epics: Epic[];
+  backlog: Backlog | null;
+}
+
+const allTasks = (data: unknown): Task[] => {
+  const board = data as BoardData;
+  return [
+    ...board.releases.flatMap((r) => r.tasks),
+    ...board.epics.flatMap((e) => e.tasks),
+    ...(board.backlog?.tasks ?? []),
+  ];
+};
+
+const ids = (data: unknown): string[] => allTasks(data).map((t) => t.frontmatter.id);
+
+const findTask = (data: unknown, id: string): Task => {
+  const task = allTasks(data).find((t) => t.frontmatter.id === id);
+  if (task === undefined) throw new Error(`task ${id} not found`);
+  return task;
+};
+
+describe('cli commands (integration)', () => {
+  let project: string;
+  let ctx: CommandContext;
+
+  beforeEach(async () => {
+    project = await mkdtemp(join(tmpdir(), 'bd-cli-cmd-'));
+    ctx = { cwd: project, json: true, dataDir: join(project, '.boardown') };
+  });
+
+  afterEach(async () => {
+    await rm(project, { recursive: true, force: true });
+  });
+
+  it('init creates a config that loads', async () => {
+    const out = await initCommand(
+      parseArgs(['init', '--id-prefix', 'TS', '--project-name', 'Demo']),
+      ctx,
+    );
+    expect((out.data as { config: BoardConfig }).config.idPrefix).toBe('TS');
+    const config = await readFile(join(project, '.boardown', 'config.yaml'), 'utf8');
+    expect(config).toContain('idPrefix: TS');
+    expect(config).toContain('projectName: Demo');
+  });
+
+  it('add → board → edit → status → rm round-trips', async () => {
+    await initCommand(parseArgs(['init', '--id-prefix', 'TS', '--project-name', 'Demo']), ctx);
+
+    const add = await taskCommand(parseArgs(['task', 'add', 'My first task', '--type', 'feature']), ctx);
+    const added = add.data as { task: Task; file: string };
+    expect(added.task.frontmatter.id).toBe('TS-1');
+    expect(added.file).toBe('epics/no_epic.md');
+
+    const board = await boardCommand(parseArgs(['board']), ctx);
+    expect(ids(board.data)).toContain('TS-1');
+
+    const add2 = await taskCommand(parseArgs(['task', 'add', 'Second', '--type', 'bug']), ctx);
+    expect((add2.data as { task: Task }).task.frontmatter.id).toBe('TS-2');
+
+    await taskCommand(parseArgs(['task', 'status', 'TS-1', 'done']), ctx);
+    await taskCommand(parseArgs(['task', 'edit', 'TS-1', '--title', 'Renamed']), ctx);
+
+    const board2 = await boardCommand(parseArgs(['board']), ctx);
+    const t1 = findTask(board2.data, 'TS-1');
+    expect(t1.title).toBe('Renamed');
+    expect(t1.frontmatter.status).toBe('done');
+
+    const removed = await taskCommand(parseArgs(['task', 'rm', 'TS-2']), ctx);
+    expect((removed.data as { removed: string }).removed).toBe('TS-2');
+
+    const board3 = await boardCommand(parseArgs(['board']), ctx);
+    expect(ids(board3.data)).not.toContain('TS-2');
+  });
+
+  it('fails to add a task to a missing epic', async () => {
+    await initCommand(parseArgs(['init', '--id-prefix', 'TS']), ctx);
+    await expect(
+      taskCommand(parseArgs(['task', 'add', 'X', '--epic', 'ghost']), ctx),
+    ).rejects.toThrow(/epic/i);
+  });
+
+  it('reports NO_BOARD when no board exists', async () => {
+    await expect(boardCommand(parseArgs(['board']), ctx)).rejects.toMatchObject({
+      code: 'NO_BOARD',
+    });
+  });
+
+  it('refuses to clobber a file changed on disk since load (CONFLICT)', async () => {
+    await initCommand(parseArgs(['init', '--id-prefix', 'TS']), ctx);
+    await taskCommand(parseArgs(['task', 'add', 'One']), ctx);
+
+    const { fs } = await loadBoardOrThrow(join(project, '.boardown'));
+    // Simulate an external edit (another process, git pull) after load.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await writeFile(join(project, '.boardown', 'epics', 'no_epic.md'), '---\n{}\n---\n', 'utf8');
+
+    await expect(fs.write('epics/no_epic.md', 'whatever')).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
+  });
+});

--- a/packages/cli/src/commands/deepening.test.ts
+++ b/packages/cli/src/commands/deepening.test.ts
@@ -48,7 +48,7 @@ describe('release / epic / move (deepening layer)', () => {
       .data as { release: Release };
     expect(started.release.frontmatter.status).toBe('current');
 
-    await taskCommand(parseArgs(['task', 'move', 'TS-1', '--release', release.release.slug]), ctx);
+    await taskCommand(parseArgs(['task', 'edit', 'TS-1', '--release', release.release.slug]), ctx);
     const afterMove = await board(ctx);
     expect(hasTask(afterMove.releases.find((r) => r.slug === release.release.slug)?.tasks, 'TS-1')).toBe(
       true,
@@ -77,23 +77,48 @@ describe('release / epic / move (deepening layer)', () => {
     ).rejects.toMatchObject({ code: 'RELEASE_CONFLICT' });
   });
 
-  it('epic add, move a task into it (tags the task), then edit the epic name', async () => {
+  it('epic add, reassign a task to it via edit --epic, then edit the epic name', async () => {
     await taskCommand(parseArgs(['task', 'add', 'Platform work']), ctx);
     const epic = (await epicCommand(parseArgs(['epic', 'add', 'Platform', '--color', '#ff0000']), ctx))
       .data as { epic: Epic };
     expect(epic.epic.frontmatter.color).toBe('#ff0000');
 
-    await taskCommand(parseArgs(['task', 'move', 'TS-1', '--epic', epic.epic.slug]), ctx);
-    const afterMove = await board(ctx);
-    const inEpic = afterMove.epics
-      .find((e) => e.slug === epic.epic.slug)
-      ?.tasks.find((t) => t.frontmatter.id === 'TS-1');
-    expect(inEpic?.frontmatter.epic).toBe(epic.epic.slug);
+    // For a backlog task, --epic relocates it into the epic's file (where the tag
+    // sticks); a task in a release would just be retagged in place.
+    await taskCommand(parseArgs(['task', 'edit', 'TS-1', '--epic', epic.epic.slug]), ctx);
+    const got = await taskCommand(parseArgs(['task', 'get', 'TS-1']), ctx);
+    expect((got.data as { task: Task }).task.frontmatter.epic).toBe(epic.epic.slug);
 
     await epicCommand(parseArgs(['epic', 'edit', epic.epic.slug, '--name', 'Platform 2']), ctx);
     const afterEdit = await board(ctx);
     expect(afterEdit.epics.find((e) => e.slug === epic.epic.slug)?.frontmatter.name).toBe(
       'Platform 2',
+    );
+  });
+
+  it('edit --release moves a task in, --no-release moves it back to the backlog', async () => {
+    await taskCommand(parseArgs(['task', 'add', 'Roundtrip']), ctx);
+    const release = (await releaseCommand(parseArgs(['release', 'add', 'rt']), ctx)).data as {
+      release: Release;
+    };
+    await releaseCommand(parseArgs(['release', 'start', release.release.slug]), ctx);
+
+    // combined field edit + move in one call
+    await taskCommand(
+      parseArgs(['task', 'edit', 'TS-1', '--status', 'in-progress', '--release', release.release.slug]),
+      ctx,
+    );
+    let board2 = await board(ctx);
+    const moved = board2.releases
+      .find((r) => r.slug === release.release.slug)
+      ?.tasks.find((t) => t.frontmatter.id === 'TS-1');
+    expect(moved?.frontmatter.status).toBe('in-progress');
+
+    await taskCommand(parseArgs(['task', 'edit', 'TS-1', '--no-release']), ctx);
+    board2 = await board(ctx);
+    expect(hasTask(board2.backlog?.tasks, 'TS-1')).toBe(true);
+    expect(hasTask(board2.releases.find((r) => r.slug === release.release.slug)?.tasks, 'TS-1')).toBe(
+      false,
     );
   });
 
@@ -109,10 +134,10 @@ describe('release / epic / move (deepening layer)', () => {
     ).rejects.toMatchObject({ code: 'USAGE' });
   });
 
-  it('task move requires exactly one destination', async () => {
+  it('edit rejects --release together with --no-release', async () => {
     await taskCommand(parseArgs(['task', 'add', 'X']), ctx);
-    await expect(taskCommand(parseArgs(['task', 'move', 'TS-1']), ctx)).rejects.toMatchObject({
-      code: 'USAGE',
-    });
+    await expect(
+      taskCommand(parseArgs(['task', 'edit', 'TS-1', '--release', 'rt', '--no-release']), ctx),
+    ).rejects.toMatchObject({ code: 'USAGE' });
   });
 });

--- a/packages/cli/src/commands/deepening.test.ts
+++ b/packages/cli/src/commands/deepening.test.ts
@@ -140,4 +140,26 @@ describe('release / epic / move (deepening layer)', () => {
       taskCommand(parseArgs(['task', 'edit', 'TS-1', '--release', 'rt', '--no-release']), ctx),
     ).rejects.toMatchObject({ code: 'USAGE' });
   });
+
+  it('a finished release is read-only: task mutations fail with code ARCHIVED', async () => {
+    await taskCommand(parseArgs(['task', 'add', 'Shipped']), ctx);
+    const release = (await releaseCommand(parseArgs(['release', 'add', 'r']), ctx)).data as {
+      release: Release;
+    };
+    await releaseCommand(parseArgs(['release', 'start', release.release.slug]), ctx);
+    await taskCommand(parseArgs(['task', 'edit', 'TS-1', '--release', release.release.slug]), ctx);
+    await taskCommand(parseArgs(['task', 'status', 'TS-1', 'done']), ctx);
+    await releaseCommand(parseArgs(['release', 'done', release.release.slug]), ctx);
+
+    // TS-1 was done, so it stayed in the now-finished release.
+    await expect(
+      taskCommand(parseArgs(['task', 'edit', 'TS-1', '--title', 'X']), ctx),
+    ).rejects.toMatchObject({ code: 'ARCHIVED' });
+    await expect(taskCommand(parseArgs(['task', 'rm', 'TS-1']), ctx)).rejects.toMatchObject({
+      code: 'ARCHIVED',
+    });
+    await expect(
+      taskCommand(parseArgs(['task', 'add', 'Late', '--release', release.release.slug]), ctx),
+    ).rejects.toMatchObject({ code: 'ARCHIVED' });
+  });
 });

--- a/packages/cli/src/commands/deepening.test.ts
+++ b/packages/cli/src/commands/deepening.test.ts
@@ -1,0 +1,118 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Backlog, Epic, Release, Task } from '@boardown/core';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { parseArgs } from '../args';
+import type { CommandContext } from '../types';
+import { boardCommand } from './board';
+import { epicCommand } from './epic';
+import { initCommand } from './init';
+import { releaseCommand } from './release';
+import { taskCommand } from './task';
+
+interface BoardData {
+  releases: Release[];
+  epics: Epic[];
+  backlog: Backlog | null;
+}
+
+const board = async (ctx: CommandContext): Promise<BoardData> =>
+  (await boardCommand(parseArgs(['board']), ctx)).data as BoardData;
+
+const hasTask = (tasks: readonly Task[] | undefined, id: string): boolean =>
+  (tasks ?? []).some((t) => t.frontmatter.id === id);
+
+describe('release / epic / move (deepening layer)', () => {
+  let project: string;
+  let ctx: CommandContext;
+
+  beforeEach(async () => {
+    project = await mkdtemp(join(tmpdir(), 'bd-cli-deep-'));
+    ctx = { cwd: project, json: true, dataDir: join(project, '.boardown') };
+    await initCommand(parseArgs(['init', '--id-prefix', 'TS', '--project-name', 'Demo']), ctx);
+  });
+
+  afterEach(async () => {
+    await rm(project, { recursive: true, force: true });
+  });
+
+  it('release add → start → moves a task in → done sends it back to the backlog', async () => {
+    await taskCommand(parseArgs(['task', 'add', 'Ship it']), ctx);
+    const release = (await releaseCommand(parseArgs(['release', 'add', 'v1']), ctx)).data as {
+      release: Release;
+    };
+    expect(release.release.frontmatter.status).toBe('future');
+
+    const started = (await releaseCommand(parseArgs(['release', 'start', release.release.slug]), ctx))
+      .data as { release: Release };
+    expect(started.release.frontmatter.status).toBe('current');
+
+    await taskCommand(parseArgs(['task', 'move', 'TS-1', '--release', release.release.slug]), ctx);
+    const afterMove = await board(ctx);
+    expect(hasTask(afterMove.releases.find((r) => r.slug === release.release.slug)?.tasks, 'TS-1')).toBe(
+      true,
+    );
+    expect(hasTask(afterMove.backlog?.tasks, 'TS-1')).toBe(false);
+
+    await releaseCommand(parseArgs(['release', 'done', release.release.slug]), ctx);
+    const afterDone = await board(ctx);
+    expect(afterDone.releases.find((r) => r.slug === release.release.slug)?.frontmatter.status).toBe(
+      'finished',
+    );
+    // The task was still open, so it returns to the backlog (it has no epic).
+    expect(hasTask(afterDone.backlog?.tasks, 'TS-1')).toBe(true);
+  });
+
+  it('only one release can be current at a time', async () => {
+    const a = (await releaseCommand(parseArgs(['release', 'add', 'a']), ctx)).data as {
+      release: Release;
+    };
+    const b = (await releaseCommand(parseArgs(['release', 'add', 'b']), ctx)).data as {
+      release: Release;
+    };
+    await releaseCommand(parseArgs(['release', 'start', a.release.slug]), ctx);
+    await expect(
+      releaseCommand(parseArgs(['release', 'start', b.release.slug]), ctx),
+    ).rejects.toMatchObject({ code: 'RELEASE_CONFLICT' });
+  });
+
+  it('epic add, move a task into it (tags the task), then edit the epic name', async () => {
+    await taskCommand(parseArgs(['task', 'add', 'Platform work']), ctx);
+    const epic = (await epicCommand(parseArgs(['epic', 'add', 'Platform', '--color', '#ff0000']), ctx))
+      .data as { epic: Epic };
+    expect(epic.epic.frontmatter.color).toBe('#ff0000');
+
+    await taskCommand(parseArgs(['task', 'move', 'TS-1', '--epic', epic.epic.slug]), ctx);
+    const afterMove = await board(ctx);
+    const inEpic = afterMove.epics
+      .find((e) => e.slug === epic.epic.slug)
+      ?.tasks.find((t) => t.frontmatter.id === 'TS-1');
+    expect(inEpic?.frontmatter.epic).toBe(epic.epic.slug);
+
+    await epicCommand(parseArgs(['epic', 'edit', epic.epic.slug, '--name', 'Platform 2']), ctx);
+    const afterEdit = await board(ctx);
+    expect(afterEdit.epics.find((e) => e.slug === epic.epic.slug)?.frontmatter.name).toBe(
+      'Platform 2',
+    );
+  });
+
+  it('rejects an invalid epic color and editing a color', async () => {
+    await expect(
+      epicCommand(parseArgs(['epic', 'add', 'Bad', '--color', 'red']), ctx),
+    ).rejects.toMatchObject({ code: 'USAGE' });
+
+    const epic = (await epicCommand(parseArgs(['epic', 'add', 'Ok', '--color', '#00ff00']), ctx))
+      .data as { epic: Epic };
+    await expect(
+      epicCommand(parseArgs(['epic', 'edit', epic.epic.slug, '--color', '#000000']), ctx),
+    ).rejects.toMatchObject({ code: 'USAGE' });
+  });
+
+  it('task move requires exactly one destination', async () => {
+    await taskCommand(parseArgs(['task', 'add', 'X']), ctx);
+    await expect(taskCommand(parseArgs(['task', 'move', 'TS-1']), ctx)).rejects.toMatchObject({
+      code: 'USAGE',
+    });
+  });
+});

--- a/packages/cli/src/commands/epic.ts
+++ b/packages/cli/src/commands/epic.ts
@@ -9,6 +9,7 @@ import {
 import { flagString, type ParsedArgs } from '../args';
 import { CliError } from '../output';
 import {
+  epicMembers,
   findEpic,
   loadBoardOrThrow,
   resolveBoardRoot,
@@ -24,6 +25,11 @@ const DEFAULT_COLOR = '#888888';
 export const epicCommand: CommandHandler = (args, ctx) => {
   const sub = args.positionals[1];
   switch (sub) {
+    case 'get':
+    case 'show':
+      return epicGet(args, ctx);
+    case 'list':
+      return epicList(args, ctx);
     case 'add':
       return epicAdd(args, ctx);
     case 'edit':
@@ -31,7 +37,7 @@ export const epicCommand: CommandHandler = (args, ctx) => {
     default:
       throw new CliError(
         'USAGE',
-        `Unknown epic subcommand "${sub ?? ''}". Use: add | edit.`,
+        `Unknown epic subcommand "${sub ?? ''}". Use: get | list | add | edit.`,
         2,
       );
   }
@@ -39,6 +45,48 @@ export const epicCommand: CommandHandler = (args, ctx) => {
 
 const problemsField = (problems: LoadedBoard['problems']): Pick<CommandOutput, 'problems'> =>
   problems.length > 0 ? { problems } : {};
+
+async function epicGet(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
+  const slug = args.positionals[2];
+  if (slug === undefined) {
+    throw new CliError('USAGE', 'Usage: boardown epic get <slug>.', 2);
+  }
+
+  const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
+  const board = await loadBoardOrThrow(root);
+  const epic = findEpic(board.snapshot, slug);
+  if (epic === undefined) {
+    throw new CliError('EPIC_NOT_FOUND', `No epic "${slug}".`);
+  }
+  const tasks = epicMembers(board.snapshot, epic);
+
+  const lines = [`Epic ${epic.frontmatter.name}  (${epic.slug})  ${epic.frontmatter.color}`];
+  for (const task of tasks) {
+    lines.push(`  ${task.frontmatter.id}  [${task.frontmatter.status}]  ${task.title}`);
+  }
+  return {
+    data: { epic, tasks },
+    human: lines.join('\n'),
+    ...problemsField(board.problems),
+  };
+}
+
+async function epicList(_args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
+  const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
+  const board = await loadBoardOrThrow(root);
+  const epics = board.snapshot.epics.map((epic) => ({
+    slug: epic.slug,
+    name: epic.frontmatter.name,
+    color: epic.frontmatter.color,
+    taskCount: epicMembers(board.snapshot, epic).length,
+  }));
+
+  const human =
+    epics.length > 0
+      ? epics.map((e) => `${e.slug}  ${e.name}  (${e.taskCount} tasks)`).join('\n')
+      : 'No epics.';
+  return { data: { epics }, human, ...problemsField(board.problems) };
+}
 
 async function epicAdd(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
   const name = args.positionals[2];

--- a/packages/cli/src/commands/epic.ts
+++ b/packages/cli/src/commands/epic.ts
@@ -1,0 +1,112 @@
+import {
+  createEpic,
+  editEpic,
+  serializeEpic,
+  type Epic,
+  type EpicPatch,
+  type NewEpicInput,
+} from '@boardown/core';
+import { flagString, type ParsedArgs } from '../args';
+import { CliError } from '../output';
+import {
+  findEpic,
+  loadBoardOrThrow,
+  resolveBoardRoot,
+  type LoadedBoard,
+} from '../persistence';
+import type { CommandContext, CommandHandler, CommandOutput } from '../types';
+
+// boardown stores epic colors as 6-digit hex; core's createEpic does not
+// validate the value, so the CLI guards it before writing.
+const HEX_COLOR = /^#[0-9a-fA-F]{6}$/;
+const DEFAULT_COLOR = '#888888';
+
+export const epicCommand: CommandHandler = (args, ctx) => {
+  const sub = args.positionals[1];
+  switch (sub) {
+    case 'add':
+      return epicAdd(args, ctx);
+    case 'edit':
+      return epicEdit(args, ctx);
+    default:
+      throw new CliError(
+        'USAGE',
+        `Unknown epic subcommand "${sub ?? ''}". Use: add | edit.`,
+        2,
+      );
+  }
+};
+
+const problemsField = (problems: LoadedBoard['problems']): Pick<CommandOutput, 'problems'> =>
+  problems.length > 0 ? { problems } : {};
+
+async function epicAdd(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
+  const name = args.positionals[2];
+  if (name === undefined || name.length === 0) {
+    throw new CliError('USAGE', 'Usage: boardown epic add <name> [--color #rrggbb] [--description ...].', 2);
+  }
+
+  const color = flagString(args.flags, 'color') ?? DEFAULT_COLOR;
+  if (!HEX_COLOR.test(color)) {
+    throw new CliError('USAGE', `--color must be a 6-digit hex like #1f6feb (got "${color}").`, 2);
+  }
+  const description = flagString(args.flags, 'description');
+
+  const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
+  const board = await loadBoardOrThrow(root);
+
+  const input: NewEpicInput = {
+    name,
+    color,
+    ...(description !== undefined ? { description } : {}),
+  };
+
+  let epic: Epic;
+  try {
+    epic = createEpic(board.snapshot.epics, input);
+  } catch (err) {
+    throw new CliError('EPIC_INVALID', err instanceof Error ? err.message : String(err), 2);
+  }
+
+  await board.fs.write(epic.filename, serializeEpic(epic));
+  return {
+    data: { epic },
+    human: `Created epic "${epic.frontmatter.name}" (${epic.slug}).`,
+    ...problemsField(board.problems),
+  };
+}
+
+async function epicEdit(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
+  const slug = args.positionals[2];
+  if (slug === undefined) {
+    throw new CliError('USAGE', 'Usage: boardown epic edit <slug> [--name ...] [--description ...].', 2);
+  }
+  if (flagString(args.flags, 'color') !== undefined) {
+    throw new CliError('USAGE', 'Editing an epic color is not supported; edit the file directly.', 2);
+  }
+
+  const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
+  const board = await loadBoardOrThrow(root);
+  const epic = findEpic(board.snapshot, slug);
+  if (epic === undefined) {
+    throw new CliError('EPIC_NOT_FOUND', `No epic "${slug}".`);
+  }
+
+  const patch: EpicPatch = {};
+  const name = flagString(args.flags, 'name');
+  if (name !== undefined) patch.name = name;
+  const description = flagString(args.flags, 'description');
+  if (description !== undefined) patch.preamble = description;
+
+  if (Object.keys(patch).length === 0) {
+    throw new CliError('USAGE', 'Nothing to edit. Provide --name and/or --description.', 2);
+  }
+
+  const updated = editEpic(epic, patch);
+  await board.fs.write(updated.filename, serializeEpic(updated));
+  return {
+    data: { epic: updated },
+    human: `Updated epic ${slug}.`,
+    ...problemsField(board.problems),
+  };
+}

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -1,0 +1,42 @@
+import { basename, isAbsolute, resolve } from 'node:path';
+import { CONFIG_FILENAME, ID_PREFIX_REGEX, serializeConfig, type BoardConfig } from '@boardown/core';
+import { flagString } from '../args';
+import { BOARD_DIRNAME } from '../board-root';
+import { NodeFsAdapter } from '../node-fs';
+import { CliError } from '../output';
+import type { CommandHandler } from '../types';
+
+export const initCommand: CommandHandler = async (args, ctx) => {
+  const projectDir = resolve(ctx.cwd);
+  const boardRoot =
+    ctx.dataDir !== undefined
+      ? isAbsolute(ctx.dataDir)
+        ? ctx.dataDir
+        : resolve(ctx.cwd, ctx.dataDir)
+      : resolve(projectDir, BOARD_DIRNAME);
+
+  const fs = new NodeFsAdapter(boardRoot);
+  if ((await fs.stat(CONFIG_FILENAME)) !== null) {
+    throw new CliError('ALREADY_INITIALIZED', `Board already initialized at ${boardRoot}.`);
+  }
+
+  const idPrefix = flagString(args.flags, 'id-prefix') ?? 'TASK';
+  if (!ID_PREFIX_REGEX.test(idPrefix)) {
+    throw new CliError('USAGE', `--id-prefix must be 2-5 uppercase letters (got "${idPrefix}").`, 2);
+  }
+
+  const projectNameFlag = flagString(args.flags, 'project-name');
+  if (projectNameFlag !== undefined && projectNameFlag.length === 0) {
+    throw new CliError('USAGE', '--project-name cannot be empty.', 2);
+  }
+  const projectName = projectNameFlag ?? (basename(projectDir) || 'Board');
+
+  const config: BoardConfig = { idPrefix, nextId: 1, projectName };
+
+  await fs.write(CONFIG_FILENAME, serializeConfig(config));
+
+  return {
+    data: { boardRoot, config },
+    human: `Initialized boardown at ${boardRoot} (idPrefix ${idPrefix}, project "${projectName}").`,
+  };
+};

--- a/packages/cli/src/commands/read.test.ts
+++ b/packages/cli/src/commands/read.test.ts
@@ -1,0 +1,121 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { Backlog, Epic, Release, Task } from '@boardown/core';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { parseArgs } from '../args';
+import type { CommandContext } from '../types';
+import { boardCommand } from './board';
+import { epicCommand } from './epic';
+import { initCommand } from './init';
+import { releaseCommand } from './release';
+import { taskCommand } from './task';
+
+const backlogOrder = async (ctx: CommandContext): Promise<string[]> => {
+  const data = (await boardCommand(parseArgs(['board']), ctx)).data as {
+    backlog: Backlog | null;
+  };
+  return [...(data.backlog?.tasks ?? [])]
+    .sort((a, b) => a.frontmatter.order - b.frontmatter.order)
+    .map((t) => t.frontmatter.id);
+};
+
+describe('read + reorder commands', () => {
+  let project: string;
+  let ctx: CommandContext;
+
+  beforeEach(async () => {
+    project = await mkdtemp(join(tmpdir(), 'bd-cli-read-'));
+    ctx = { cwd: project, json: true, dataDir: join(project, '.boardown') };
+    await initCommand(parseArgs(['init', '--id-prefix', 'TS', '--project-name', 'Demo']), ctx);
+  });
+
+  afterEach(async () => {
+    await rm(project, { recursive: true, force: true });
+  });
+
+  it('task get returns the task and its location', async () => {
+    await taskCommand(parseArgs(['task', 'add', 'One']), ctx);
+    const got = await taskCommand(parseArgs(['task', 'get', 'TS-1']), ctx);
+    const data = got.data as { task: Task; in: { kind: string; file: string } };
+    expect(data.task.frontmatter.id).toBe('TS-1');
+    expect(data.in.kind).toBe('backlog');
+    await expect(taskCommand(parseArgs(['task', 'get', 'TS-99']), ctx)).rejects.toMatchObject({
+      code: 'TASK_NOT_FOUND',
+    });
+  });
+
+  it('epic list and epic get report epic membership', async () => {
+    const created = (
+      await epicCommand(parseArgs(['epic', 'add', 'Core', '--color', '#1f6feb']), ctx)
+    ).data as { epic: Epic };
+    await taskCommand(parseArgs(['task', 'add', 'x', '--epic', created.epic.slug]), ctx);
+
+    const list = (await epicCommand(parseArgs(['epic', 'list']), ctx)).data as {
+      epics: { slug: string; taskCount: number }[];
+    };
+    expect(list.epics.find((e) => e.slug === created.epic.slug)?.taskCount).toBe(1);
+
+    const get = (await epicCommand(parseArgs(['epic', 'get', created.epic.slug]), ctx)).data as {
+      tasks: Task[];
+    };
+    expect(get.tasks).toHaveLength(1);
+  });
+
+  it('release list, get, and current', async () => {
+    const created = (await releaseCommand(parseArgs(['release', 'add', 'v1']), ctx)).data as {
+      release: Release;
+    };
+
+    const list = (await releaseCommand(parseArgs(['release', 'list']), ctx)).data as {
+      releases: { slug: string; status: string }[];
+    };
+    expect(list.releases.some((r) => r.slug === created.release.slug)).toBe(true);
+
+    const noCurrent = (await releaseCommand(parseArgs(['release', 'current']), ctx)).data as {
+      release: Release | null;
+    };
+    expect(noCurrent.release).toBeNull();
+
+    await releaseCommand(parseArgs(['release', 'start', created.release.slug]), ctx);
+    const current = (await releaseCommand(parseArgs(['release', 'current']), ctx)).data as {
+      release: Release | null;
+    };
+    expect(current.release?.slug).toBe(created.release.slug);
+
+    const get = (await releaseCommand(parseArgs(['release', 'get', created.release.slug]), ctx))
+      .data as { release: Release };
+    expect(get.release.slug).toBe(created.release.slug);
+  });
+
+  it('task reorder moves a card up / down / before within its container', async () => {
+    await taskCommand(parseArgs(['task', 'add', 'A']), ctx);
+    await taskCommand(parseArgs(['task', 'add', 'B']), ctx);
+    await taskCommand(parseArgs(['task', 'add', 'C']), ctx);
+    expect(await backlogOrder(ctx)).toEqual(['TS-1', 'TS-2', 'TS-3']);
+
+    await taskCommand(parseArgs(['task', 'reorder', 'TS-3', '--up']), ctx);
+    expect(await backlogOrder(ctx)).toEqual(['TS-1', 'TS-3', 'TS-2']);
+
+    await taskCommand(parseArgs(['task', 'reorder', 'TS-1', '--down']), ctx);
+    expect(await backlogOrder(ctx)).toEqual(['TS-3', 'TS-1', 'TS-2']);
+
+    await taskCommand(parseArgs(['task', 'reorder', 'TS-2', '--before', 'TS-3']), ctx);
+    expect(await backlogOrder(ctx)).toEqual(['TS-2', 'TS-3', 'TS-1']);
+  });
+
+  it('task reorder requires exactly one direction flag', async () => {
+    await taskCommand(parseArgs(['task', 'add', 'A']), ctx);
+    await expect(taskCommand(parseArgs(['task', 'reorder', 'TS-1']), ctx)).rejects.toMatchObject({
+      code: 'USAGE',
+    });
+  });
+
+  it('task reorder rejects placing a task before itself', async () => {
+    await taskCommand(parseArgs(['task', 'add', 'A']), ctx);
+    await taskCommand(parseArgs(['task', 'add', 'B']), ctx);
+    await expect(
+      taskCommand(parseArgs(['task', 'reorder', 'TS-1', '--before', 'TS-1']), ctx),
+    ).rejects.toMatchObject({ code: 'USAGE' });
+  });
+});

--- a/packages/cli/src/commands/release.ts
+++ b/packages/cli/src/commands/release.ts
@@ -6,12 +6,14 @@ import {
   serializeEpic,
   serializeRelease,
   startRelease,
+  type CompleteReleaseResult,
   type NewReleaseInput,
   type Release,
 } from '@boardown/core';
 import { flagString, type ParsedArgs } from '../args';
 import { CliError } from '../output';
 import {
+  currentRelease,
   findRelease,
   loadBoardOrThrow,
   resolveBoardRoot,
@@ -22,6 +24,14 @@ import type { CommandContext, CommandHandler, CommandOutput } from '../types';
 export const releaseCommand: CommandHandler = (args, ctx) => {
   const sub = args.positionals[1];
   switch (sub) {
+    case 'get':
+    case 'show':
+      return releaseGet(args, ctx);
+    case 'list':
+      return releaseList(args, ctx);
+    case 'current':
+    case 'active':
+      return releaseCurrent(args, ctx);
     case 'add':
       return releaseAdd(args, ctx);
     case 'start':
@@ -33,11 +43,69 @@ export const releaseCommand: CommandHandler = (args, ctx) => {
     default:
       throw new CliError(
         'USAGE',
-        `Unknown release subcommand "${sub ?? ''}". Use: add | start | done.`,
+        `Unknown release subcommand "${sub ?? ''}". Use: get | list | current | add | start | done.`,
         2,
       );
   }
 };
+
+const renderRelease = (release: Release): string => {
+  const name = release.frontmatter.name ?? release.slug;
+  const lines = [`[${release.frontmatter.status}] ${name}  (${release.filename})`];
+  for (const task of release.tasks) {
+    lines.push(`  ${task.frontmatter.id}  [${task.frontmatter.status}]  ${task.title}`);
+  }
+  return lines.join('\n');
+};
+
+async function releaseGet(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
+  const ref = args.positionals[2];
+  if (ref === undefined) {
+    throw new CliError('USAGE', 'Usage: boardown release get <file|slug>.', 2);
+  }
+  const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
+  const board = await loadBoardOrThrow(root);
+  const release = requireRelease(board, ref);
+  return {
+    data: { release },
+    human: renderRelease(release),
+    ...problemsField(board.problems),
+  };
+}
+
+async function releaseList(_args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
+  const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
+  const board = await loadBoardOrThrow(root);
+  const releases = board.snapshot.releases.map((release) => ({
+    slug: release.slug,
+    name: release.frontmatter.name ?? release.slug,
+    status: release.frontmatter.status,
+    taskCount: release.tasks.length,
+  }));
+  const human =
+    releases.length > 0
+      ? releases.map((r) => `[${r.status}] ${r.slug}  ${r.name}  (${r.taskCount} tasks)`).join('\n')
+      : 'No releases.';
+  return { data: { releases }, human, ...problemsField(board.problems) };
+}
+
+async function releaseCurrent(_args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
+  const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
+  const board = await loadBoardOrThrow(root);
+  const release = currentRelease(board.snapshot);
+  if (release === undefined) {
+    return {
+      data: { release: null },
+      human: 'No current release.',
+      ...problemsField(board.problems),
+    };
+  }
+  return {
+    data: { release },
+    human: renderRelease(release),
+    ...problemsField(board.problems),
+  };
+}
 
 const problemsField = (problems: LoadedBoard['problems']): Pick<CommandOutput, 'problems'> =>
   problems.length > 0 ? { problems } : {};
@@ -118,12 +186,19 @@ async function releaseDone(args: ParsedArgs, ctx: CommandContext): Promise<Comma
   const intoRef = flagString(args.flags, 'into');
   const targetRelease = intoRef !== undefined ? requireRelease(board, intoRef) : null;
 
-  const result = completeRelease({
-    release,
-    epics: board.snapshot.epics,
-    backlog: board.snapshot.backlog ?? emptyBacklog(),
-    targetRelease,
-  });
+  let result: CompleteReleaseResult;
+  try {
+    result = completeRelease({
+      release,
+      epics: board.snapshot.epics,
+      backlog: board.snapshot.backlog ?? emptyBacklog(),
+      targetRelease,
+    });
+  } catch (err) {
+    // core rejects completing a non-current release (and carrying into a
+    // finished one); surface it as a structured error.
+    throw new CliError('RELEASE_NOT_CURRENT', err instanceof Error ? err.message : String(err));
+  }
 
   // Persist every container the redistribution actually touched.
   const changed = new Set(result.changedFilenames);

--- a/packages/cli/src/commands/release.ts
+++ b/packages/cli/src/commands/release.ts
@@ -1,0 +1,152 @@
+import {
+  completeRelease,
+  createRelease,
+  emptyBacklog,
+  serializeBacklog,
+  serializeEpic,
+  serializeRelease,
+  startRelease,
+  type NewReleaseInput,
+  type Release,
+} from '@boardown/core';
+import { flagString, type ParsedArgs } from '../args';
+import { CliError } from '../output';
+import {
+  findRelease,
+  loadBoardOrThrow,
+  resolveBoardRoot,
+  type LoadedBoard,
+} from '../persistence';
+import type { CommandContext, CommandHandler, CommandOutput } from '../types';
+
+export const releaseCommand: CommandHandler = (args, ctx) => {
+  const sub = args.positionals[1];
+  switch (sub) {
+    case 'add':
+      return releaseAdd(args, ctx);
+    case 'start':
+      return releaseStart(args, ctx);
+    case 'done':
+    case 'complete':
+    case 'finish':
+      return releaseDone(args, ctx);
+    default:
+      throw new CliError(
+        'USAGE',
+        `Unknown release subcommand "${sub ?? ''}". Use: add | start | done.`,
+        2,
+      );
+  }
+};
+
+const problemsField = (problems: LoadedBoard['problems']): Pick<CommandOutput, 'problems'> =>
+  problems.length > 0 ? { problems } : {};
+
+const requireRelease = (board: LoadedBoard, ref: string): Release => {
+  const release = findRelease(board.snapshot, ref);
+  if (release === undefined) {
+    throw new CliError('RELEASE_NOT_FOUND', `No release "${ref}".`);
+  }
+  return release;
+};
+
+async function releaseAdd(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
+  const name = args.positionals[2];
+  if (name === undefined || name.length === 0) {
+    throw new CliError('USAGE', 'Usage: boardown release add <name> [--description ...].', 2);
+  }
+
+  const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
+  const board = await loadBoardOrThrow(root);
+  const description = flagString(args.flags, 'description');
+
+  const input: NewReleaseInput = {
+    name,
+    ...(description !== undefined ? { description } : {}),
+  };
+
+  let release: Release;
+  try {
+    release = createRelease(board.snapshot.releases, input);
+  } catch (err) {
+    throw new CliError('RELEASE_INVALID', err instanceof Error ? err.message : String(err), 2);
+  }
+
+  await board.fs.write(release.filename, serializeRelease(release));
+  return {
+    data: { release },
+    human: `Created release "${release.frontmatter.name ?? release.slug}" (${release.filename}).`,
+    ...problemsField(board.problems),
+  };
+}
+
+async function releaseStart(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
+  const ref = args.positionals[2];
+  if (ref === undefined) {
+    throw new CliError('USAGE', 'Usage: boardown release start <file|slug>.', 2);
+  }
+
+  const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
+  const board = await loadBoardOrThrow(root);
+  const release = requireRelease(board, ref);
+
+  let started: Release;
+  try {
+    started = startRelease(release, board.snapshot.releases);
+  } catch (err) {
+    throw new CliError('RELEASE_CONFLICT', err instanceof Error ? err.message : String(err));
+  }
+
+  await board.fs.write(started.filename, serializeRelease(started));
+  return {
+    data: { release: started },
+    human: `Started release ${started.frontmatter.name ?? started.slug} (now current).`,
+    ...problemsField(board.problems),
+  };
+}
+
+async function releaseDone(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
+  const ref = args.positionals[2];
+  if (ref === undefined) {
+    throw new CliError('USAGE', 'Usage: boardown release done <file|slug> [--into <release>].', 2);
+  }
+
+  const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
+  const board = await loadBoardOrThrow(root);
+  const release = requireRelease(board, ref);
+
+  const intoRef = flagString(args.flags, 'into');
+  const targetRelease = intoRef !== undefined ? requireRelease(board, intoRef) : null;
+
+  const result = completeRelease({
+    release,
+    epics: board.snapshot.epics,
+    backlog: board.snapshot.backlog ?? emptyBacklog(),
+    targetRelease,
+  });
+
+  // Persist every container the redistribution actually touched.
+  const changed = new Set(result.changedFilenames);
+  await board.fs.write(result.release.filename, serializeRelease(result.release));
+  if (result.targetRelease !== null && changed.has(result.targetRelease.filename)) {
+    await board.fs.write(result.targetRelease.filename, serializeRelease(result.targetRelease));
+  }
+  for (const epic of result.epics) {
+    if (changed.has(epic.filename)) {
+      await board.fs.write(epic.filename, serializeEpic(epic));
+    }
+  }
+  if (result.backlog !== null && changed.has(result.backlog.filename)) {
+    await board.fs.write(result.backlog.filename, serializeBacklog(result.backlog));
+  }
+
+  return {
+    data: {
+      release: result.release,
+      movedTo: result.targetRelease?.filename ?? null,
+      changedFiles: result.changedFilenames,
+    },
+    human: `Finished release ${result.release.frontmatter.name ?? result.release.slug}.`,
+    ...problemsField(board.problems),
+  };
+}

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -35,8 +35,9 @@ const DESCRIPTOR = {
     {
       name: 'task edit',
       usage:
-        'boardown task edit <id> [--title T] [--description D] [--type TYPE] [--status STATUS] [--epic SLUG | --no-epic]',
-      summary: 'Edit a task in place.',
+        'boardown task edit <id> [--title T] [--description D] [--type TYPE] [--status STATUS] [--epic SLUG | --no-epic] [--release REF | --no-release]',
+      summary:
+        'Edit a task. --release/--no-release move it in/out of a release; --epic/--no-epic reassign the epic (relocates a backlog/epic task, retags a task in a release).',
     },
     {
       name: 'task status',
@@ -47,11 +48,6 @@ const DESCRIPTOR = {
       name: 'task reorder',
       usage: 'boardown task reorder <id> (--before ID | --after ID | --up | --down)',
       summary: "Change a task's priority (order) within its container.",
-    },
-    {
-      name: 'task move',
-      usage: 'boardown task move <id> (--release REF | --epic SLUG | --backlog) [--status STATUS] [--before ID]',
-      summary: 'Move a task between the backlog, an epic, and a release.',
     },
     { name: 'task rm', usage: 'boardown task rm <id>', summary: 'Delete a task.' },
     {

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -1,0 +1,87 @@
+import { RELEASE_STATUSES, TASK_STATUSES, TASK_TYPES } from '@boardown/core';
+import type { CommandHandler } from '../types';
+
+// A stable, self-describing contract for agents: valid enum values, the task
+// shape, and the command grammar. Enum values are sourced from core so they
+// never drift from the schemas.
+const DESCRIPTOR = {
+  version: 1,
+  taskTypes: TASK_TYPES,
+  taskStatuses: TASK_STATUSES,
+  releaseStatuses: RELEASE_STATUSES,
+  taskFields: {
+    id: 'string, assigned by boardown (e.g. BD-12)',
+    title: 'string',
+    description: 'string',
+    type: 'one of taskTypes',
+    status: 'one of taskStatuses',
+    epic: 'optional epic slug',
+    order: 'number, managed by boardown',
+  },
+  commands: [
+    { name: 'board', usage: 'boardown board [--json]', summary: 'Print the whole board.' },
+    {
+      name: 'init',
+      usage: 'boardown init [--id-prefix PP] [--project-name NAME]',
+      summary: 'Create a .boardown/ board in the current directory.',
+    },
+    {
+      name: 'task add',
+      usage:
+        'boardown task add <title> [--type TYPE] [--status STATUS] [--description TEXT] [--epic SLUG] [--release FILE]',
+      summary: 'Create a task in the backlog (default), an epic, or a release.',
+    },
+    {
+      name: 'task edit',
+      usage:
+        'boardown task edit <id> [--title T] [--description D] [--type TYPE] [--status STATUS] [--epic SLUG | --no-epic]',
+      summary: 'Edit a task in place.',
+    },
+    {
+      name: 'task status',
+      usage: 'boardown task status <id> <status>',
+      summary: 'Change a task status.',
+    },
+    {
+      name: 'task move',
+      usage: 'boardown task move <id> (--release REF | --epic SLUG | --backlog) [--status STATUS] [--before ID]',
+      summary: 'Move a task between the backlog, an epic, and a release.',
+    },
+    { name: 'task rm', usage: 'boardown task rm <id>', summary: 'Delete a task.' },
+    {
+      name: 'release add',
+      usage: 'boardown release add <name> [--description TEXT]',
+      summary: 'Create a future release.',
+    },
+    {
+      name: 'release start',
+      usage: 'boardown release start <file|slug>',
+      summary: 'Make a release current (only one at a time).',
+    },
+    {
+      name: 'release done',
+      usage: 'boardown release done <file|slug> [--into <release>]',
+      summary: 'Finish a release; open tasks return to epics/backlog or carry into --into.',
+    },
+    {
+      name: 'epic add',
+      usage: 'boardown epic add <name> [--color #rrggbb] [--description TEXT]',
+      summary: 'Create an epic.',
+    },
+    {
+      name: 'epic edit',
+      usage: 'boardown epic edit <slug> [--name NAME] [--description TEXT]',
+      summary: 'Rename an epic or change its description.',
+    },
+    { name: 'schema', usage: 'boardown schema [--json]', summary: 'Print this contract.' },
+  ],
+  globalFlags: {
+    '--json': 'Emit a JSON envelope (default when stdout is not a TTY).',
+    '--data-dir': 'Point at a specific .boardown/ directory instead of searching upward.',
+  },
+} as const;
+
+export const schemaCommand: CommandHandler = () => ({
+  data: DESCRIPTOR,
+  human: JSON.stringify(DESCRIPTOR, null, 2),
+});

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -25,6 +25,7 @@ const DESCRIPTOR = {
       usage: 'boardown init [--id-prefix PP] [--project-name NAME]',
       summary: 'Create a .boardown/ board in the current directory.',
     },
+    { name: 'task get', usage: 'boardown task get <id>', summary: 'Show one task and where it lives.' },
     {
       name: 'task add',
       usage:
@@ -43,11 +44,31 @@ const DESCRIPTOR = {
       summary: 'Change a task status.',
     },
     {
+      name: 'task reorder',
+      usage: 'boardown task reorder <id> (--before ID | --after ID | --up | --down)',
+      summary: "Change a task's priority (order) within its container.",
+    },
+    {
       name: 'task move',
       usage: 'boardown task move <id> (--release REF | --epic SLUG | --backlog) [--status STATUS] [--before ID]',
       summary: 'Move a task between the backlog, an epic, and a release.',
     },
     { name: 'task rm', usage: 'boardown task rm <id>', summary: 'Delete a task.' },
+    {
+      name: 'release get',
+      usage: 'boardown release get <file|slug>',
+      summary: 'Show one release and its tasks.',
+    },
+    {
+      name: 'release list',
+      usage: 'boardown release list',
+      summary: 'List releases (slug, status, task count).',
+    },
+    {
+      name: 'release current',
+      usage: 'boardown release current',
+      summary: 'Show the current release and its tasks (null if none).',
+    },
     {
       name: 'release add',
       usage: 'boardown release add <name> [--description TEXT]',
@@ -62,6 +83,16 @@ const DESCRIPTOR = {
       name: 'release done',
       usage: 'boardown release done <file|slug> [--into <release>]',
       summary: 'Finish a release; open tasks return to epics/backlog or carry into --into.',
+    },
+    {
+      name: 'epic get',
+      usage: 'boardown epic get <slug>',
+      summary: 'Show one epic and all its tasks.',
+    },
+    {
+      name: 'epic list',
+      usage: 'boardown epic list',
+      summary: 'List epics (slug, name, color, task count).',
     },
     {
       name: 'epic add',

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -6,10 +6,12 @@ import {
   emptyBacklog,
   moveTaskBetweenContainers,
   moveTaskInContainer,
+  reorderTask,
   TASK_STATUSES,
   TASK_TYPES,
   type DestEpic,
   type NewTaskInput,
+  type Task,
   type TaskPatch,
   type TaskStatus,
   type TaskType,
@@ -31,12 +33,17 @@ import type { CommandContext, CommandHandler, CommandOutput } from '../types';
 export const taskCommand: CommandHandler = (args, ctx) => {
   const sub = args.positionals[1];
   switch (sub) {
+    case 'get':
+    case 'show':
+      return taskGet(args, ctx);
     case 'add':
       return taskAdd(args, ctx);
     case 'edit':
       return taskEdit(args, ctx);
     case 'status':
       return taskStatus(args, ctx);
+    case 'reorder':
+      return taskReorder(args, ctx);
     case 'move':
       return taskMove(args, ctx);
     case 'rm':
@@ -46,7 +53,7 @@ export const taskCommand: CommandHandler = (args, ctx) => {
     default:
       throw new CliError(
         'USAGE',
-        `Unknown task subcommand "${sub ?? ''}". Use: add | edit | status | move | rm.`,
+        `Unknown task subcommand "${sub ?? ''}". Use: get | add | edit | status | reorder | move | rm.`,
         2,
       );
   }
@@ -210,6 +217,132 @@ async function taskStatus(args: ParsedArgs, ctx: CommandContext): Promise<Comman
   const task = updated.tasks.find((t) => t.frontmatter.id === id);
 
   return { data: { task }, human: `${id} → ${status}.`, ...problemsField(problems) };
+}
+
+const renderTask = (task: Task, kind: string, file: string): string => {
+  const fm = task.frontmatter;
+  const epic = fm.epic !== undefined ? `  epic:${fm.epic}` : '';
+  const body = task.description.length > 0 ? `\n\n${task.description}` : '';
+  return `${fm.id}  [${fm.type}/${fm.status}]${epic}  (${kind}: ${file})\n${task.title}${body}`;
+};
+
+async function taskGet(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
+  const id = args.positionals[2];
+  if (id === undefined) {
+    throw new CliError('USAGE', 'Usage: boardown task get <id>.', 2);
+  }
+
+  const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
+  const { snapshot, problems } = await loadBoardOrThrow(root);
+  const location = locateTask(snapshot, id);
+  if (location === null) {
+    throw new CliError('TASK_NOT_FOUND', `No task "${id}".`);
+  }
+  const task = location.container.tasks.find((t) => t.frontmatter.id === id);
+  if (task === undefined) {
+    throw new CliError('TASK_NOT_FOUND', `No task "${id}".`);
+  }
+
+  return {
+    data: { task, in: { kind: location.kind, file: location.container.filename } },
+    human: renderTask(task, location.kind, location.container.filename),
+    ...problemsField(problems),
+  };
+}
+
+type ReorderTarget =
+  | { kind: 'before'; anchor: string }
+  | { kind: 'after'; anchor: string }
+  | { kind: 'up' }
+  | { kind: 'down' };
+
+function reorderTarget(args: ParsedArgs): ReorderTarget {
+  const before = flagString(args.flags, 'before');
+  const after = flagString(args.flags, 'after');
+  const up = flagBool(args.flags, 'up');
+  const down = flagBool(args.flags, 'down');
+  if ([before !== undefined, after !== undefined, up, down].filter(Boolean).length !== 1) {
+    throw new CliError(
+      'USAGE',
+      'Provide exactly one of: --before <id> | --after <id> | --up | --down.',
+      2,
+    );
+  }
+  if (before !== undefined) return { kind: 'before', anchor: before };
+  if (after !== undefined) return { kind: 'after', anchor: after };
+  return up ? { kind: 'up' } : { kind: 'down' };
+}
+
+// Translate a human "move" into the `beforeTaskId` core's reorderTask expects
+// (null = place last). Returns undefined when the task is already at the
+// requested edge — a no-op the caller can skip.
+function beforeIdForReorder(
+  tasks: readonly Task[],
+  taskId: string,
+  target: ReorderTarget,
+): string | null | undefined {
+  if ((target.kind === 'before' || target.kind === 'after') && target.anchor === taskId) {
+    throw new CliError('USAGE', `Cannot place a task ${target.kind} itself.`);
+  }
+  const sorted = [...tasks].sort((a, b) => a.frontmatter.order - b.frontmatter.order);
+  const idx = sorted.findIndex((t) => t.frontmatter.id === taskId);
+  switch (target.kind) {
+    case 'before':
+      if (!sorted.some((t) => t.frontmatter.id === target.anchor)) {
+        throw new CliError('TASK_NOT_FOUND', `No task "${target.anchor}" in the same container.`);
+      }
+      return target.anchor;
+    case 'after': {
+      const at = sorted.findIndex((t) => t.frontmatter.id === target.anchor);
+      if (at === -1) {
+        throw new CliError('TASK_NOT_FOUND', `No task "${target.anchor}" in the same container.`);
+      }
+      return sorted[at + 1]?.frontmatter.id ?? null;
+    }
+    case 'up':
+      return idx <= 0 ? undefined : sorted[idx - 1]?.frontmatter.id;
+    case 'down':
+      return idx >= sorted.length - 1 ? undefined : (sorted[idx + 2]?.frontmatter.id ?? null);
+  }
+}
+
+async function taskReorder(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
+  const id = args.positionals[2];
+  if (id === undefined) {
+    throw new CliError(
+      'USAGE',
+      'Usage: boardown task reorder <id> (--before <id> | --after <id> | --up | --down).',
+      2,
+    );
+  }
+  const target = reorderTarget(args);
+
+  const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
+  const { fs, snapshot, problems } = await loadBoardOrThrow(root);
+  const location = locateTask(snapshot, id);
+  if (location === null) {
+    throw new CliError('TASK_NOT_FOUND', `No task "${id}".`);
+  }
+
+  const beforeTaskId = beforeIdForReorder(location.container.tasks, id, target);
+  if (beforeTaskId === undefined) {
+    const task = location.container.tasks.find((t) => t.frontmatter.id === id);
+    return {
+      data: { task, file: location.container.filename, moved: false },
+      human: `${id} is already at the edge; nothing to do.`,
+      ...problemsField(problems),
+    };
+  }
+
+  const updated = reorderTask(location.container, id, beforeTaskId);
+  await writeContainer(fs, { kind: location.kind, container: updated });
+  const task = updated.tasks.find((t) => t.frontmatter.id === id);
+
+  return {
+    data: { task, file: updated.filename, moved: true },
+    human: `Reordered ${id} in ${updated.filename}.`,
+    ...problemsField(problems),
+  };
 }
 
 async function taskMove(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -87,6 +87,18 @@ function requireStatus(value: string): TaskStatus {
 const problemsField = (out: CommandOutput['problems']): Pick<CommandOutput, 'problems'> =>
   out !== undefined && out.length > 0 ? { problems: out } : {};
 
+// Run a core board-op, mapping its process-guard rejection (a finished release is
+// read-only and rejects new or moved work) to a structured ARCHIVED error rather
+// than the generic ERROR fallback. The task's existence is validated before
+// these calls, so a thrown error is always the finished-release guard.
+function applyOp<T>(fn: () => T): T {
+  try {
+    return fn();
+  } catch (err) {
+    throw new CliError('ARCHIVED', err instanceof Error ? err.message : String(err));
+  }
+}
+
 async function taskAdd(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
   const title = args.positionals[2];
   if (title === undefined || title.length === 0) {
@@ -142,7 +154,7 @@ async function taskAdd(args: ParsedArgs, ctx: CommandContext): Promise<CommandOu
     ...(epicTag !== undefined ? { epic: epicTag } : {}),
   };
 
-  const result = createTask(target.container, snapshot.config, input);
+  const result = applyOp(() => createTask(target.container, snapshot.config, input));
   await writeContainer(fs, { kind: target.kind, container: result.container });
   await writeConfig(fs, result.config);
 
@@ -213,11 +225,13 @@ async function moveAndReport(
   if (movingTask === undefined) {
     throw new CliError('TASK_NOT_FOUND', `No task "${taskId}".`);
   }
-  const result = moveTaskBetweenContainers(edited, dest.container, taskId, {
-    newStatus: movingTask.frontmatter.status,
-    beforeTaskId: null,
-    destEpic: dest.destEpic,
-  });
+  const result = applyOp(() =>
+    moveTaskBetweenContainers(edited, dest.container, taskId, {
+      newStatus: movingTask.frontmatter.status,
+      beforeTaskId: null,
+      destEpic: dest.destEpic,
+    }),
+  );
   await writeContainer(fs, { kind: location.kind, container: result.source });
   await writeContainer(fs, { kind: dest.kind, container: result.dest });
   const task = result.dest.tasks.find((t) => t.frontmatter.id === taskId);
@@ -284,7 +298,7 @@ async function taskEdit(args: ParsedArgs, ctx: CommandContext): Promise<CommandO
 
   // Release relocation: move in/out of a release, keeping the epic tag.
   if (changesRelease) {
-    const edited = hasFields ? editTask(location.container, id, fields) : location.container;
+    const edited = hasFields ? applyOp(() => editTask(location.container, id, fields)) : location.container;
     const dest = resolveReleaseMove(snapshot, location, edited, id, releaseRef, noRelease);
     if (dest === null) {
       await writeContainer(fs, { kind: location.kind, container: edited });
@@ -308,7 +322,7 @@ async function taskEdit(args: ParsedArgs, ctx: CommandContext): Promise<CommandO
       (typeof nextEpic === 'string' && nextEpic !== current.frontmatter.epic));
 
   if (epicReallyChanges && location.kind !== 'release') {
-    const edited = hasFields ? editTask(location.container, id, fields) : location.container;
+    const edited = hasFields ? applyOp(() => editTask(location.container, id, fields)) : location.container;
     let dest: MoveDest;
     if (nextEpic === null) {
       dest = { kind: 'backlog', container: snapshot.backlog ?? emptyBacklog(), destEpic: { kind: 'clear' } };
@@ -325,7 +339,7 @@ async function taskEdit(args: ParsedArgs, ctx: CommandContext): Promise<CommandO
   // Pure in-place edit (fields, plus epic tag when the task is in a release).
   const patch: TaskPatch = { ...fields };
   if (nextEpic !== undefined) patch.epic = nextEpic;
-  const edited = editTask(location.container, id, patch);
+  const edited = applyOp(() => editTask(location.container, id, patch));
   await writeContainer(fs, { kind: location.kind, container: edited });
   const task = edited.tasks.find((t) => t.frontmatter.id === id);
   return { data: { task, file: edited.filename }, human: `Updated ${id}.`, ...problemsField(problems) };
@@ -346,7 +360,7 @@ async function taskStatus(args: ParsedArgs, ctx: CommandContext): Promise<Comman
     throw new CliError('TASK_NOT_FOUND', `No task "${id}".`);
   }
 
-  const updated = changeTaskStatus(location.container, id, status);
+  const updated = applyOp(() => changeTaskStatus(location.container, id, status));
   await writeContainer(fs, { kind: location.kind, container: updated });
   const task = updated.tasks.find((t) => t.frontmatter.id === id);
 
@@ -468,7 +482,7 @@ async function taskReorder(args: ParsedArgs, ctx: CommandContext): Promise<Comma
     };
   }
 
-  const updated = reorderTask(location.container, id, beforeTaskId);
+  const updated = applyOp(() => reorderTask(location.container, id, beforeTaskId));
   await writeContainer(fs, { kind: location.kind, container: updated });
   const task = updated.tasks.find((t) => t.frontmatter.id === id);
 
@@ -492,7 +506,7 @@ async function taskRm(args: ParsedArgs, ctx: CommandContext): Promise<CommandOut
     throw new CliError('TASK_NOT_FOUND', `No task "${id}".`);
   }
 
-  const updated = deleteTask(location.container, id);
+  const updated = applyOp(() => deleteTask(location.container, id));
   await writeContainer(fs, { kind: location.kind, container: updated });
 
   return {

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -1,0 +1,324 @@
+import {
+  changeTaskStatus,
+  createTask,
+  deleteTask,
+  editTask,
+  emptyBacklog,
+  moveTaskBetweenContainers,
+  moveTaskInContainer,
+  TASK_STATUSES,
+  TASK_TYPES,
+  type DestEpic,
+  type NewTaskInput,
+  type TaskPatch,
+  type TaskStatus,
+  type TaskType,
+} from '@boardown/core';
+import { flagBool, flagString, type ParsedArgs } from '../args';
+import { CliError } from '../output';
+import {
+  findEpic,
+  findRelease,
+  loadBoardOrThrow,
+  locateTask,
+  resolveBoardRoot,
+  writeConfig,
+  writeContainer,
+  type ContainerRef,
+} from '../persistence';
+import type { CommandContext, CommandHandler, CommandOutput } from '../types';
+
+export const taskCommand: CommandHandler = (args, ctx) => {
+  const sub = args.positionals[1];
+  switch (sub) {
+    case 'add':
+      return taskAdd(args, ctx);
+    case 'edit':
+      return taskEdit(args, ctx);
+    case 'status':
+      return taskStatus(args, ctx);
+    case 'move':
+      return taskMove(args, ctx);
+    case 'rm':
+    case 'remove':
+    case 'delete':
+      return taskRm(args, ctx);
+    default:
+      throw new CliError(
+        'USAGE',
+        `Unknown task subcommand "${sub ?? ''}". Use: add | edit | status | move | rm.`,
+        2,
+      );
+  }
+};
+
+const isTaskType = (value: string): value is TaskType =>
+  (TASK_TYPES as readonly string[]).includes(value);
+
+const isTaskStatus = (value: string): value is TaskStatus =>
+  (TASK_STATUSES as readonly string[]).includes(value);
+
+function requireType(value: string | undefined, fallback: TaskType): TaskType {
+  if (value === undefined) return fallback;
+  if (!isTaskType(value)) {
+    throw new CliError('USAGE', `Invalid --type "${value}" (one of ${TASK_TYPES.join(', ')}).`, 2);
+  }
+  return value;
+}
+
+function requireStatus(value: string): TaskStatus {
+  if (!isTaskStatus(value)) {
+    throw new CliError(
+      'USAGE',
+      `Invalid status "${value}" (one of ${TASK_STATUSES.join(', ')}).`,
+      2,
+    );
+  }
+  return value;
+}
+
+const problemsField = (out: CommandOutput['problems']): Pick<CommandOutput, 'problems'> =>
+  out !== undefined && out.length > 0 ? { problems: out } : {};
+
+async function taskAdd(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
+  const title = args.positionals[2];
+  if (title === undefined || title.length === 0) {
+    throw new CliError(
+      'USAGE',
+      'Usage: boardown task add <title> [--type ...] [--epic ...] [--release ...].',
+      2,
+    );
+  }
+
+  const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
+  const { fs, snapshot, problems } = await loadBoardOrThrow(root);
+
+  const type = requireType(flagString(args.flags, 'type'), 'feature');
+  const statusFlag = flagString(args.flags, 'status');
+  const status = statusFlag === undefined ? 'todo' : requireStatus(statusFlag);
+  const description = flagString(args.flags, 'description');
+  const releaseRef = flagString(args.flags, 'release');
+  const epicSlug = flagString(args.flags, 'epic');
+
+  let target: ContainerRef;
+  let epicTag: string | undefined;
+
+  if (releaseRef !== undefined) {
+    const release = snapshot.releases.find(
+      (r) => r.filename === releaseRef || r.slug === releaseRef,
+    );
+    if (release === undefined) {
+      throw new CliError('RELEASE_NOT_FOUND', `No release "${releaseRef}".`);
+    }
+    if (epicSlug !== undefined && !snapshot.epics.some((e) => e.slug === epicSlug)) {
+      throw new CliError('EPIC_NOT_FOUND', `No epic "${epicSlug}".`);
+    }
+    target = { kind: 'release', container: release };
+    epicTag = epicSlug;
+  } else if (epicSlug !== undefined) {
+    const epic = snapshot.epics.find((e) => e.slug === epicSlug);
+    if (epic === undefined) {
+      throw new CliError('EPIC_NOT_FOUND', `No epic "${epicSlug}".`);
+    }
+    target = { kind: 'epic', container: epic };
+    epicTag = epicSlug;
+  } else {
+    target = { kind: 'backlog', container: snapshot.backlog ?? emptyBacklog() };
+    epicTag = undefined;
+  }
+
+  const input: NewTaskInput = {
+    title,
+    type,
+    status,
+    ...(description !== undefined ? { description } : {}),
+    ...(epicTag !== undefined ? { epic: epicTag } : {}),
+  };
+
+  const result = createTask(target.container, snapshot.config, input);
+  await writeContainer(fs, { kind: target.kind, container: result.container });
+  await writeConfig(fs, result.config);
+
+  return {
+    data: { task: result.task, file: result.container.filename },
+    human: `Created ${result.task.frontmatter.id} "${result.task.title}" in ${result.container.filename}.`,
+    ...problemsField(problems),
+  };
+}
+
+async function taskEdit(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
+  const id = args.positionals[2];
+  if (id === undefined) {
+    throw new CliError('USAGE', 'Usage: boardown task edit <id> [--title ...] [--status ...] ...', 2);
+  }
+
+  const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
+  const { fs, snapshot, problems } = await loadBoardOrThrow(root);
+  const location = locateTask(snapshot, id);
+  if (location === null) {
+    throw new CliError('TASK_NOT_FOUND', `No task "${id}".`);
+  }
+
+  const patch: TaskPatch = {};
+  const title = flagString(args.flags, 'title');
+  if (title !== undefined) patch.title = title;
+  const description = flagString(args.flags, 'description');
+  if (description !== undefined) patch.description = description;
+  const typeFlag = flagString(args.flags, 'type');
+  if (typeFlag !== undefined) patch.type = requireType(typeFlag, 'feature');
+  const statusFlag = flagString(args.flags, 'status');
+  if (statusFlag !== undefined) patch.status = requireStatus(statusFlag);
+  if (flagBool(args.flags, 'no-epic')) {
+    patch.epic = null;
+  } else {
+    const epicSlug = flagString(args.flags, 'epic');
+    if (epicSlug !== undefined) patch.epic = epicSlug;
+  }
+
+  if (Object.keys(patch).length === 0) {
+    throw new CliError(
+      'USAGE',
+      'Nothing to edit. Provide at least one of --title/--description/--type/--status/--epic/--no-epic.',
+      2,
+    );
+  }
+
+  const updated = editTask(location.container, id, patch);
+  await writeContainer(fs, { kind: location.kind, container: updated });
+  const task = updated.tasks.find((t) => t.frontmatter.id === id);
+
+  return { data: { task }, human: `Updated ${id}.`, ...problemsField(problems) };
+}
+
+async function taskStatus(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
+  const id = args.positionals[2];
+  const statusArg = args.positionals[3];
+  if (id === undefined || statusArg === undefined) {
+    throw new CliError('USAGE', 'Usage: boardown task status <id> <status>.', 2);
+  }
+  const status = requireStatus(statusArg);
+
+  const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
+  const { fs, snapshot, problems } = await loadBoardOrThrow(root);
+  const location = locateTask(snapshot, id);
+  if (location === null) {
+    throw new CliError('TASK_NOT_FOUND', `No task "${id}".`);
+  }
+
+  const updated = changeTaskStatus(location.container, id, status);
+  await writeContainer(fs, { kind: location.kind, container: updated });
+  const task = updated.tasks.find((t) => t.frontmatter.id === id);
+
+  return { data: { task }, human: `${id} → ${status}.`, ...problemsField(problems) };
+}
+
+async function taskMove(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
+  const id = args.positionals[2];
+  if (id === undefined) {
+    throw new CliError(
+      'USAGE',
+      'Usage: boardown task move <id> (--release <r> | --epic <slug> | --backlog) [--status ...] [--before <id>].',
+      2,
+    );
+  }
+
+  const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
+  const { fs, snapshot, problems } = await loadBoardOrThrow(root);
+  const source = locateTask(snapshot, id);
+  if (source === null) {
+    throw new CliError('TASK_NOT_FOUND', `No task "${id}".`);
+  }
+  const task = source.container.tasks.find((t) => t.frontmatter.id === id);
+  if (task === undefined) {
+    throw new CliError('TASK_NOT_FOUND', `No task "${id}".`);
+  }
+
+  const releaseRef = flagString(args.flags, 'release');
+  const epicSlug = flagString(args.flags, 'epic');
+  const toBacklog = flagBool(args.flags, 'backlog');
+  const destinations = [releaseRef !== undefined, epicSlug !== undefined, toBacklog].filter(
+    Boolean,
+  ).length;
+  if (destinations !== 1) {
+    throw new CliError(
+      'USAGE',
+      'Provide exactly one destination: --release <r> | --epic <slug> | --backlog.',
+      2,
+    );
+  }
+
+  const statusFlag = flagString(args.flags, 'status');
+  const newStatus = statusFlag === undefined ? task.frontmatter.status : requireStatus(statusFlag);
+  const beforeTaskId = flagString(args.flags, 'before') ?? null;
+
+  let dest: ContainerRef;
+  let destEpic: DestEpic;
+  if (releaseRef !== undefined) {
+    const release = findRelease(snapshot, releaseRef);
+    if (release === undefined) {
+      throw new CliError('RELEASE_NOT_FOUND', `No release "${releaseRef}".`);
+    }
+    dest = { kind: 'release', container: release };
+    destEpic = { kind: 'preserve' };
+  } else if (epicSlug !== undefined) {
+    const epic = findEpic(snapshot, epicSlug);
+    if (epic === undefined) {
+      throw new CliError('EPIC_NOT_FOUND', `No epic "${epicSlug}".`);
+    }
+    dest = { kind: 'epic', container: epic };
+    destEpic = { kind: 'set', slug: epic.slug };
+  } else {
+    dest = { kind: 'backlog', container: snapshot.backlog ?? emptyBacklog() };
+    destEpic = { kind: 'clear' };
+  }
+
+  // Same file → an in-place reorder/status change, not a cross-container move.
+  if (source.container.filename === dest.container.filename) {
+    const updated = moveTaskInContainer(source.container, id, { status: newStatus, beforeTaskId });
+    await writeContainer(fs, { kind: source.kind, container: updated });
+    const moved = updated.tasks.find((t) => t.frontmatter.id === id);
+    return {
+      data: { task: moved, file: updated.filename },
+      human: `Moved ${id} within ${updated.filename}.`,
+      ...problemsField(problems),
+    };
+  }
+
+  const result = moveTaskBetweenContainers(source.container, dest.container, id, {
+    newStatus,
+    beforeTaskId,
+    destEpic,
+  });
+  await writeContainer(fs, { kind: source.kind, container: result.source });
+  await writeContainer(fs, { kind: dest.kind, container: result.dest });
+  const moved = result.dest.tasks.find((t) => t.frontmatter.id === id);
+
+  return {
+    data: { task: moved, from: result.source.filename, to: result.dest.filename },
+    human: `Moved ${id} → ${result.dest.filename}.`,
+    ...problemsField(problems),
+  };
+}
+
+async function taskRm(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
+  const id = args.positionals[2];
+  if (id === undefined) {
+    throw new CliError('USAGE', 'Usage: boardown task rm <id>.', 2);
+  }
+
+  const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
+  const { fs, snapshot, problems } = await loadBoardOrThrow(root);
+  const location = locateTask(snapshot, id);
+  if (location === null) {
+    throw new CliError('TASK_NOT_FOUND', `No task "${id}".`);
+  }
+
+  const updated = deleteTask(location.container, id);
+  await writeContainer(fs, { kind: location.kind, container: updated });
+
+  return {
+    data: { removed: id, file: updated.filename },
+    human: `Removed ${id} from ${updated.filename}.`,
+    ...problemsField(problems),
+  };
+}

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -5,12 +5,14 @@ import {
   editTask,
   emptyBacklog,
   moveTaskBetweenContainers,
-  moveTaskInContainer,
   reorderTask,
   TASK_STATUSES,
   TASK_TYPES,
+  type BoardSnapshot,
   type DestEpic,
+  type FsAdapter,
   type NewTaskInput,
+  type ParseProblem,
   type Task,
   type TaskPatch,
   type TaskStatus,
@@ -44,8 +46,6 @@ export const taskCommand: CommandHandler = (args, ctx) => {
       return taskStatus(args, ctx);
     case 'reorder':
       return taskReorder(args, ctx);
-    case 'move':
-      return taskMove(args, ctx);
     case 'rm':
     case 'remove':
     case 'delete':
@@ -53,7 +53,7 @@ export const taskCommand: CommandHandler = (args, ctx) => {
     default:
       throw new CliError(
         'USAGE',
-        `Unknown task subcommand "${sub ?? ''}". Use: get | add | edit | status | reorder | move | rm.`,
+        `Unknown task subcommand "${sub ?? ''}". Use: get | add | edit | status | reorder | rm.`,
         2,
       );
   }
@@ -153,10 +153,106 @@ async function taskAdd(args: ParsedArgs, ctx: CommandContext): Promise<CommandOu
   };
 }
 
+interface MoveDest {
+  kind: ContainerRef['kind'];
+  container: ContainerRef['container'];
+  destEpic: DestEpic;
+}
+
+// Resolve where a --release / --no-release edit moves the task (mirrors the UI's
+// Release selector / moveTaskToRelease). Returns null when no move is needed.
+function resolveReleaseMove(
+  snapshot: BoardSnapshot,
+  location: ContainerRef,
+  edited: ContainerRef['container'],
+  taskId: string,
+  releaseRef: string | undefined,
+  noRelease: boolean,
+): MoveDest | null {
+  if (releaseRef !== undefined) {
+    const release = findRelease(snapshot, releaseRef);
+    if (release === undefined) {
+      throw new CliError('RELEASE_NOT_FOUND', `No release "${releaseRef}".`);
+    }
+    if (edited.filename === release.filename) return null;
+    return { kind: 'release', container: release, destEpic: { kind: 'preserve' } };
+  }
+  if (noRelease) {
+    // Removing from a release falls back to the task's epic file, or the
+    // backlog when it has no epic. A no-op when the task isn't in a release.
+    if (location.kind !== 'release') return null;
+    const epicSlug = edited.tasks.find((t) => t.frontmatter.id === taskId)?.frontmatter.epic;
+    if (epicSlug !== undefined) {
+      const epic = findEpic(snapshot, epicSlug);
+      if (epic === undefined) {
+        throw new CliError('EPIC_NOT_FOUND', `No epic "${epicSlug}".`);
+      }
+      return { kind: 'epic', container: epic, destEpic: { kind: 'set', slug: epicSlug } };
+    }
+    return { kind: 'backlog', container: snapshot.backlog ?? emptyBacklog(), destEpic: { kind: 'clear' } };
+  }
+  return null;
+}
+
+// Apply a resolved relocation: write the patched container if the task is
+// already in the destination, otherwise move it and write both files.
+async function moveAndReport(
+  fs: FsAdapter,
+  location: ContainerRef,
+  edited: ContainerRef['container'],
+  dest: MoveDest,
+  taskId: string,
+  problems: ParseProblem[],
+): Promise<CommandOutput> {
+  if (edited.filename === dest.container.filename) {
+    await writeContainer(fs, { kind: location.kind, container: edited });
+    const task = edited.tasks.find((t) => t.frontmatter.id === taskId);
+    return { data: { task, file: edited.filename }, human: `Updated ${taskId}.`, ...problemsField(problems) };
+  }
+  const movingTask = edited.tasks.find((t) => t.frontmatter.id === taskId);
+  if (movingTask === undefined) {
+    throw new CliError('TASK_NOT_FOUND', `No task "${taskId}".`);
+  }
+  const result = moveTaskBetweenContainers(edited, dest.container, taskId, {
+    newStatus: movingTask.frontmatter.status,
+    beforeTaskId: null,
+    destEpic: dest.destEpic,
+  });
+  await writeContainer(fs, { kind: location.kind, container: result.source });
+  await writeContainer(fs, { kind: dest.kind, container: result.dest });
+  const task = result.dest.tasks.find((t) => t.frontmatter.id === taskId);
+  return {
+    data: { task, from: result.source.filename, to: result.dest.filename },
+    human: `Updated ${taskId}; moved to ${result.dest.filename}.`,
+    ...problemsField(problems),
+  };
+}
+
 async function taskEdit(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
   const id = args.positionals[2];
   if (id === undefined) {
-    throw new CliError('USAGE', 'Usage: boardown task edit <id> [--title ...] [--status ...] ...', 2);
+    throw new CliError(
+      'USAGE',
+      'Usage: boardown task edit <id> [--title/--description/--type/--status/--epic/--no-epic] [--release <ref> | --no-release].',
+      2,
+    );
+  }
+
+  const releaseRef = flagString(args.flags, 'release');
+  const noRelease = flagBool(args.flags, 'no-release');
+  const noEpic = flagBool(args.flags, 'no-epic');
+  const epicSlug = flagString(args.flags, 'epic');
+  if (releaseRef !== undefined && noRelease) {
+    throw new CliError('USAGE', 'Use either --release <ref> or --no-release, not both.', 2);
+  }
+  const changesRelease = releaseRef !== undefined || noRelease;
+  const changesEpic = epicSlug !== undefined || noEpic;
+  if (changesRelease && changesEpic) {
+    throw new CliError(
+      'USAGE',
+      'Change --release/--no-release and --epic/--no-epic in separate edits.',
+      2,
+    );
   }
 
   const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
@@ -166,35 +262,73 @@ async function taskEdit(args: ParsedArgs, ctx: CommandContext): Promise<CommandO
     throw new CliError('TASK_NOT_FOUND', `No task "${id}".`);
   }
 
-  const patch: TaskPatch = {};
+  // Field-only patch (epic/release relocation handled separately below).
+  const fields: TaskPatch = {};
   const title = flagString(args.flags, 'title');
-  if (title !== undefined) patch.title = title;
+  if (title !== undefined) fields.title = title;
   const description = flagString(args.flags, 'description');
-  if (description !== undefined) patch.description = description;
+  if (description !== undefined) fields.description = description;
   const typeFlag = flagString(args.flags, 'type');
-  if (typeFlag !== undefined) patch.type = requireType(typeFlag, 'feature');
+  if (typeFlag !== undefined) fields.type = requireType(typeFlag, 'feature');
   const statusFlag = flagString(args.flags, 'status');
-  if (statusFlag !== undefined) patch.status = requireStatus(statusFlag);
-  if (flagBool(args.flags, 'no-epic')) {
-    patch.epic = null;
-  } else {
-    const epicSlug = flagString(args.flags, 'epic');
-    if (epicSlug !== undefined) patch.epic = epicSlug;
-  }
+  if (statusFlag !== undefined) fields.status = requireStatus(statusFlag);
+  const hasFields = Object.keys(fields).length > 0;
 
-  if (Object.keys(patch).length === 0) {
+  if (!hasFields && !changesRelease && !changesEpic) {
     throw new CliError(
       'USAGE',
-      'Nothing to edit. Provide at least one of --title/--description/--type/--status/--epic/--no-epic.',
+      'Nothing to edit. Provide fields and/or --release/--no-release/--epic/--no-epic.',
       2,
     );
   }
 
-  const updated = editTask(location.container, id, patch);
-  await writeContainer(fs, { kind: location.kind, container: updated });
-  const task = updated.tasks.find((t) => t.frontmatter.id === id);
+  // Release relocation: move in/out of a release, keeping the epic tag.
+  if (changesRelease) {
+    const edited = hasFields ? editTask(location.container, id, fields) : location.container;
+    const dest = resolveReleaseMove(snapshot, location, edited, id, releaseRef, noRelease);
+    if (dest === null) {
+      await writeContainer(fs, { kind: location.kind, container: edited });
+      const task = edited.tasks.find((t) => t.frontmatter.id === id);
+      return { data: { task, file: edited.filename }, human: `Updated ${id}.`, ...problemsField(problems) };
+    }
+    return moveAndReport(fs, location, edited, dest, id, problems);
+  }
 
-  return { data: { task }, human: `Updated ${id}.`, ...problemsField(problems) };
+  // Epic change. A task in a release carries the epic as a tag (edit in place);
+  // elsewhere membership is by file, so changing the epic relocates the task
+  // (the backlog serializer strips epic tags) — this mirrors store.updateTask.
+  const current = location.container.tasks.find((t) => t.frontmatter.id === id);
+  if (current === undefined) {
+    throw new CliError('TASK_NOT_FOUND', `No task "${id}".`);
+  }
+  const nextEpic: string | null | undefined = noEpic ? null : epicSlug;
+  const epicReallyChanges =
+    nextEpic !== undefined &&
+    ((nextEpic === null && current.frontmatter.epic !== undefined) ||
+      (typeof nextEpic === 'string' && nextEpic !== current.frontmatter.epic));
+
+  if (epicReallyChanges && location.kind !== 'release') {
+    const edited = hasFields ? editTask(location.container, id, fields) : location.container;
+    let dest: MoveDest;
+    if (nextEpic === null) {
+      dest = { kind: 'backlog', container: snapshot.backlog ?? emptyBacklog(), destEpic: { kind: 'clear' } };
+    } else {
+      const epic = findEpic(snapshot, nextEpic);
+      if (epic === undefined) {
+        throw new CliError('EPIC_NOT_FOUND', `No epic "${nextEpic}".`);
+      }
+      dest = { kind: 'epic', container: epic, destEpic: { kind: 'set', slug: nextEpic } };
+    }
+    return moveAndReport(fs, location, edited, dest, id, problems);
+  }
+
+  // Pure in-place edit (fields, plus epic tag when the task is in a release).
+  const patch: TaskPatch = { ...fields };
+  if (nextEpic !== undefined) patch.epic = nextEpic;
+  const edited = editTask(location.container, id, patch);
+  await writeContainer(fs, { kind: location.kind, container: edited });
+  const task = edited.tasks.find((t) => t.frontmatter.id === id);
+  return { data: { task, file: edited.filename }, human: `Updated ${id}.`, ...problemsField(problems) };
 }
 
 async function taskStatus(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
@@ -341,94 +475,6 @@ async function taskReorder(args: ParsedArgs, ctx: CommandContext): Promise<Comma
   return {
     data: { task, file: updated.filename, moved: true },
     human: `Reordered ${id} in ${updated.filename}.`,
-    ...problemsField(problems),
-  };
-}
-
-async function taskMove(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
-  const id = args.positionals[2];
-  if (id === undefined) {
-    throw new CliError(
-      'USAGE',
-      'Usage: boardown task move <id> (--release <r> | --epic <slug> | --backlog) [--status ...] [--before <id>].',
-      2,
-    );
-  }
-
-  const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
-  const { fs, snapshot, problems } = await loadBoardOrThrow(root);
-  const source = locateTask(snapshot, id);
-  if (source === null) {
-    throw new CliError('TASK_NOT_FOUND', `No task "${id}".`);
-  }
-  const task = source.container.tasks.find((t) => t.frontmatter.id === id);
-  if (task === undefined) {
-    throw new CliError('TASK_NOT_FOUND', `No task "${id}".`);
-  }
-
-  const releaseRef = flagString(args.flags, 'release');
-  const epicSlug = flagString(args.flags, 'epic');
-  const toBacklog = flagBool(args.flags, 'backlog');
-  const destinations = [releaseRef !== undefined, epicSlug !== undefined, toBacklog].filter(
-    Boolean,
-  ).length;
-  if (destinations !== 1) {
-    throw new CliError(
-      'USAGE',
-      'Provide exactly one destination: --release <r> | --epic <slug> | --backlog.',
-      2,
-    );
-  }
-
-  const statusFlag = flagString(args.flags, 'status');
-  const newStatus = statusFlag === undefined ? task.frontmatter.status : requireStatus(statusFlag);
-  const beforeTaskId = flagString(args.flags, 'before') ?? null;
-
-  let dest: ContainerRef;
-  let destEpic: DestEpic;
-  if (releaseRef !== undefined) {
-    const release = findRelease(snapshot, releaseRef);
-    if (release === undefined) {
-      throw new CliError('RELEASE_NOT_FOUND', `No release "${releaseRef}".`);
-    }
-    dest = { kind: 'release', container: release };
-    destEpic = { kind: 'preserve' };
-  } else if (epicSlug !== undefined) {
-    const epic = findEpic(snapshot, epicSlug);
-    if (epic === undefined) {
-      throw new CliError('EPIC_NOT_FOUND', `No epic "${epicSlug}".`);
-    }
-    dest = { kind: 'epic', container: epic };
-    destEpic = { kind: 'set', slug: epic.slug };
-  } else {
-    dest = { kind: 'backlog', container: snapshot.backlog ?? emptyBacklog() };
-    destEpic = { kind: 'clear' };
-  }
-
-  // Same file → an in-place reorder/status change, not a cross-container move.
-  if (source.container.filename === dest.container.filename) {
-    const updated = moveTaskInContainer(source.container, id, { status: newStatus, beforeTaskId });
-    await writeContainer(fs, { kind: source.kind, container: updated });
-    const moved = updated.tasks.find((t) => t.frontmatter.id === id);
-    return {
-      data: { task: moved, file: updated.filename },
-      human: `Moved ${id} within ${updated.filename}.`,
-      ...problemsField(problems),
-    };
-  }
-
-  const result = moveTaskBetweenContainers(source.container, dest.container, id, {
-    newStatus,
-    beforeTaskId,
-    destEpic,
-  });
-  await writeContainer(fs, { kind: source.kind, container: result.source });
-  await writeContainer(fs, { kind: dest.kind, container: result.dest });
-  const moved = result.dest.tasks.find((t) => t.frontmatter.id === id);
-
-  return {
-    data: { task: moved, from: result.source.filename, to: result.dest.filename },
-    human: `Moved ${id} → ${result.dest.filename}.`,
     ...problemsField(problems),
   };
 }

--- a/packages/cli/src/node-fs.test.ts
+++ b/packages/cli/src/node-fs.test.ts
@@ -1,0 +1,66 @@
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { NodeFsAdapter, resolveTarget } from './node-fs';
+
+describe('resolveTarget', () => {
+  it('rejects absolute paths', () => {
+    expect(resolveTarget('/board', '/etc/passwd')).toBeNull();
+  });
+
+  it('rejects `..` escapes', () => {
+    expect(resolveTarget('/board', '../secret')).toBeNull();
+  });
+
+  it('resolves a nested relative path under the root', () => {
+    expect(resolveTarget('/board', 'releases/v1.md')).toBe(join('/board', 'releases', 'v1.md'));
+  });
+});
+
+describe('NodeFsAdapter', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'bd-cli-fs-'));
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('writes and reads, creating parent directories', async () => {
+    const fs = new NodeFsAdapter(root);
+    await fs.write('epics/no_epic.md', 'hello');
+    expect(await fs.read('epics/no_epic.md')).toBe('hello');
+  });
+
+  it('list returns [] for a missing directory', async () => {
+    expect(await new NodeFsAdapter(root).list('releases')).toEqual([]);
+  });
+
+  it('list returns only files, not subdirectories', async () => {
+    const fs = new NodeFsAdapter(root);
+    await fs.write('releases/v1.md', 'x');
+    await mkdir(join(root, 'releases', 'nested'), { recursive: true });
+    const names = await fs.list('releases');
+    expect(names).toContain('v1.md');
+    expect(names).not.toContain('nested');
+  });
+
+  it('stat returns null for a missing file', async () => {
+    expect(await new NodeFsAdapter(root).stat('config.yaml')).toBeNull();
+  });
+
+  it('stat returns a lastModified for a present file', async () => {
+    const fs = new NodeFsAdapter(root);
+    await fs.write('config.yaml', 'x');
+    const stat = await fs.stat('config.yaml');
+    expect(stat).not.toBeNull();
+    expect(typeof stat?.lastModified).toBe('number');
+  });
+
+  it('refuses to write outside the board root', async () => {
+    await expect(new NodeFsAdapter(root).write('../evil.md', 'x')).rejects.toThrow();
+  });
+});

--- a/packages/cli/src/node-fs.test.ts
+++ b/packages/cli/src/node-fs.test.ts
@@ -1,6 +1,6 @@
 import { mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { NodeFsAdapter, resolveTarget } from './node-fs';
 
@@ -14,7 +14,9 @@ describe('resolveTarget', () => {
   });
 
   it('resolves a nested relative path under the root', () => {
-    expect(resolveTarget('/board', 'releases/v1.md')).toBe(join('/board', 'releases', 'v1.md'));
+    // resolveTarget uses path.resolve internally, which on Windows prefixes a
+    // drive letter — so the expectation must go through resolve() too, not join().
+    expect(resolveTarget('/board', 'releases/v1.md')).toBe(resolve('/board', 'releases', 'v1.md'));
   });
 });
 

--- a/packages/cli/src/node-fs.ts
+++ b/packages/cli/src/node-fs.ts
@@ -1,0 +1,63 @@
+import { promises as fsp } from 'node:fs';
+import { dirname, isAbsolute, normalize, resolve, sep } from 'node:path';
+import type { FileStat, FsAdapter } from '@boardown/core';
+
+// Join a board-relative path onto the board root, rejecting absolute paths and
+// any '..' escape — mirrors packages/electron's board-fs guard so a caller can
+// never reach outside the board's `.boardown/` directory.
+export function resolveTarget(boardRoot: string, userPath: string): string | null {
+  if (isAbsolute(userPath)) return null;
+  const normalized = normalize(userPath);
+  if (normalized === '..' || normalized.startsWith(`..${sep}`)) return null;
+  const root = resolve(boardRoot);
+  const target = resolve(root, normalized);
+  if (target !== root && !target.startsWith(root + sep)) return null;
+  return target;
+}
+
+const isENOENT = (err: unknown): boolean =>
+  typeof err === 'object' && err !== null && (err as { code?: string }).code === 'ENOENT';
+
+// FsAdapter backed by Node's filesystem, rooted at a board's `.boardown/`
+// directory.
+export class NodeFsAdapter implements FsAdapter {
+  constructor(private readonly boardRoot: string) {}
+
+  read(path: string): Promise<string> {
+    return fsp.readFile(this.target(path), 'utf8');
+  }
+
+  async write(path: string, content: string): Promise<void> {
+    const target = this.target(path);
+    await fsp.mkdir(dirname(target), { recursive: true });
+    await fsp.writeFile(target, content, 'utf8');
+  }
+
+  async list(dir: string): Promise<string[]> {
+    try {
+      const entries = await fsp.readdir(this.target(dir), { withFileTypes: true });
+      return entries.filter((entry) => entry.isFile()).map((entry) => entry.name);
+    } catch (err) {
+      if (isENOENT(err)) return [];
+      throw err;
+    }
+  }
+
+  async stat(path: string): Promise<FileStat | null> {
+    try {
+      const stats = await fsp.stat(this.target(path));
+      return { lastModified: stats.mtimeMs };
+    } catch (err) {
+      if (isENOENT(err)) return null;
+      throw err;
+    }
+  }
+
+  private target(path: string): string {
+    const resolved = resolveTarget(this.boardRoot, path);
+    if (resolved === null) {
+      throw new Error(`Path "${path}" escapes the board root`);
+    }
+    return resolved;
+  }
+}

--- a/packages/cli/src/output.ts
+++ b/packages/cli/src/output.ts
@@ -1,0 +1,49 @@
+import type { ParseProblem } from '@boardown/core';
+
+// A failure the CLI can describe to the caller: a stable `code` for agents to
+// branch on, a human `message`, and an `exitCode` (1 = operation failed,
+// 2 = usage error).
+export class CliError extends Error {
+  constructor(
+    readonly code: string,
+    message: string,
+    readonly exitCode: number = 1,
+    readonly problems: ParseProblem[] = [],
+  ) {
+    super(message);
+    this.name = 'CliError';
+  }
+}
+
+export interface OkEnvelope {
+  ok: true;
+  command: string;
+  data: unknown;
+  problems?: ParseProblem[];
+}
+
+export interface ErrEnvelope {
+  ok: false;
+  command: string;
+  error: { code: string; message: string };
+  problems?: ParseProblem[];
+}
+
+export function okEnvelope(
+  command: string,
+  data: unknown,
+  problems: ParseProblem[],
+): OkEnvelope {
+  return problems.length > 0
+    ? { ok: true, command, data, problems }
+    : { ok: true, command, data };
+}
+
+export function errEnvelope(command: string, err: CliError): ErrEnvelope {
+  const base: ErrEnvelope = {
+    ok: false,
+    command,
+    error: { code: err.code, message: err.message },
+  };
+  return err.problems.length > 0 ? { ...base, problems: err.problems } : base;
+}

--- a/packages/cli/src/persistence.ts
+++ b/packages/cli/src/persistence.ts
@@ -13,6 +13,7 @@ import {
   type FsAdapter,
   type ParseProblem,
   type Release,
+  type Task,
 } from '@boardown/core';
 import { findBoardRoot } from './board-root';
 import { NodeFsAdapter } from './node-fs';
@@ -73,6 +74,20 @@ export function findRelease(snapshot: BoardSnapshot, ref: string): Release | und
 
 export function findEpic(snapshot: BoardSnapshot, slug: string): Epic | undefined {
   return snapshot.epics.find((e) => e.slug === slug);
+}
+
+export function currentRelease(snapshot: BoardSnapshot): Release | undefined {
+  return snapshot.releases.find((r) => r.frontmatter.status === 'current');
+}
+
+// All tasks belonging to an epic: those physically in its file, plus tasks in
+// any release that carry the epic tag (filename is authoritative for epic
+// files; the tag carries membership once a task is scheduled into a release).
+export function epicMembers(snapshot: BoardSnapshot, epic: Epic): Task[] {
+  const tagged = snapshot.releases.flatMap((r) =>
+    r.tasks.filter((t) => t.frontmatter.epic === epic.slug),
+  );
+  return [...epic.tasks, ...tagged];
 }
 
 export function locateTask(snapshot: BoardSnapshot, taskId: string): ContainerRef | null {

--- a/packages/cli/src/persistence.ts
+++ b/packages/cli/src/persistence.ts
@@ -1,0 +1,112 @@
+import {
+  CONFIG_FILENAME,
+  createGuardedFs,
+  loadBoard,
+  serializeBacklog,
+  serializeConfig,
+  serializeEpic,
+  serializeRelease,
+  type Backlog,
+  type BoardConfig,
+  type BoardSnapshot,
+  type Epic,
+  type FsAdapter,
+  type ParseProblem,
+  type Release,
+} from '@boardown/core';
+import { findBoardRoot } from './board-root';
+import { NodeFsAdapter } from './node-fs';
+import { CliError } from './output';
+
+export type ContainerKind = 'release' | 'epic' | 'backlog';
+
+// A container paired with its kind. The kind/container shapes always agree at
+// runtime; the cast lives only in serializeContainer (mirrors ui/store.ts).
+export interface ContainerRef {
+  kind: ContainerKind;
+  container: Release | Epic | Backlog;
+}
+
+export interface LoadedBoard {
+  fs: FsAdapter;
+  snapshot: BoardSnapshot;
+  problems: ParseProblem[];
+}
+
+export async function resolveBoardRoot(cwd: string, dataDir?: string): Promise<string> {
+  const root = await findBoardRoot(cwd, dataDir);
+  if (root === null) {
+    throw new CliError(
+      'NO_BOARD',
+      dataDir !== undefined
+        ? `No .boardown directory at ${dataDir}.`
+        : `No .boardown directory found from ${cwd} upward. Run \`boardown init\` first.`,
+    );
+  }
+  return root;
+}
+
+export async function loadBoardOrThrow(root: string): Promise<LoadedBoard> {
+  const inner = new NodeFsAdapter(root);
+  const result = await loadBoard(inner);
+  if (result.kind === 'missing-config') {
+    throw new CliError('NO_BOARD', `No board config at ${root}. Run \`boardown init\` first.`);
+  }
+  if (result.kind === 'failed') {
+    throw new CliError('BOARD_INVALID', 'Board failed to load.', 1, result.problems);
+  }
+  // Same external-change guard the other shells use: refuse to clobber a file
+  // that moved on disk since load. In a CLI there's no Reload modal, so a
+  // conflict is a plain error — re-running the command re-reads the board.
+  const fs = createGuardedFs(inner, result.fileVersions, (path) => {
+    throw new CliError(
+      'CONFLICT',
+      `${path} changed on disk since the board was loaded; re-run the command.`,
+    );
+  });
+  return { fs, snapshot: result.snapshot, problems: result.problems };
+}
+
+export function findRelease(snapshot: BoardSnapshot, ref: string): Release | undefined {
+  return snapshot.releases.find((r) => r.filename === ref || r.slug === ref);
+}
+
+export function findEpic(snapshot: BoardSnapshot, slug: string): Epic | undefined {
+  return snapshot.epics.find((e) => e.slug === slug);
+}
+
+export function locateTask(snapshot: BoardSnapshot, taskId: string): ContainerRef | null {
+  for (const release of snapshot.releases) {
+    if (release.tasks.some((t) => t.frontmatter.id === taskId)) {
+      return { kind: 'release', container: release };
+    }
+  }
+  for (const epic of snapshot.epics) {
+    if (epic.tasks.some((t) => t.frontmatter.id === taskId)) {
+      return { kind: 'epic', container: epic };
+    }
+  }
+  if (snapshot.backlog?.tasks.some((t) => t.frontmatter.id === taskId)) {
+    return { kind: 'backlog', container: snapshot.backlog };
+  }
+  return null;
+}
+
+export function serializeContainer(ref: ContainerRef): string {
+  switch (ref.kind) {
+    case 'release':
+      return serializeRelease(ref.container as Release);
+    case 'epic':
+      return serializeEpic(ref.container as Epic);
+    case 'backlog':
+      return serializeBacklog(ref.container as Backlog);
+  }
+}
+
+export async function writeContainer(fs: FsAdapter, ref: ContainerRef): Promise<void> {
+  await fs.write(ref.container.filename, serializeContainer(ref));
+}
+
+export async function writeConfig(fs: FsAdapter, config: BoardConfig): Promise<void> {
+  await fs.write(CONFIG_FILENAME, serializeConfig(config));
+}

--- a/packages/cli/src/types.ts
+++ b/packages/cli/src/types.ts
@@ -1,0 +1,19 @@
+import type { ParseProblem } from '@boardown/core';
+import type { ParsedArgs } from './args';
+
+export interface CommandContext {
+  cwd: string;
+  json: boolean;
+  dataDir?: string;
+}
+
+export interface CommandOutput {
+  data: unknown;
+  human: string;
+  problems?: ParseProblem[];
+}
+
+export type CommandHandler = (
+  args: ParsedArgs,
+  ctx: CommandContext,
+) => CommandOutput | Promise<CommandOutput>;

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "vitest.config.ts"]
+}

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+});

--- a/packages/core/src/board-ops.test.ts
+++ b/packages/core/src/board-ops.test.ts
@@ -704,3 +704,57 @@ describe('startRelease', () => {
     expect(() => startRelease(r1, [active, r1])).toThrow(/already current/);
   });
 });
+
+describe('process invariants — finished release is archived', () => {
+  const finished = (...tasks: Task[]): Release => ({
+    ...release(...tasks),
+    filename: 'releases/done.md',
+    slug: 'done',
+    frontmatter: { status: 'finished' },
+  });
+
+  it('startRelease rejects a non-future release', () => {
+    expect(() => startRelease(finished(), [])).toThrow(/future/);
+    expect(() => startRelease(release(), [])).toThrow(/future/);
+  });
+
+  it('completeRelease rejects a non-current release', () => {
+    expect(() =>
+      completeRelease({
+        release: futureRelease('next'),
+        epics: [],
+        backlog: null,
+        targetRelease: null,
+      }),
+    ).toThrow(/current/);
+  });
+
+  it('createTask rejects a finished release', () => {
+    expect(() =>
+      createTask(finished(), config, { title: 'x', type: 'feature', status: 'todo' }),
+    ).toThrow(/finished/);
+  });
+
+  it('task mutations reject a finished release', () => {
+    const r = finished(task('BD-1', 'todo', 100));
+    expect(() => editTask(r, 'BD-1', { title: 'y' })).toThrow(/finished/);
+    expect(() => changeTaskStatus(r, 'BD-1', 'done')).toThrow(/finished/);
+    expect(() => deleteTask(r, 'BD-1')).toThrow(/finished/);
+    expect(() => reorderTask(r, 'BD-1', null)).toThrow(/finished/);
+  });
+
+  it('moveTaskBetweenContainers rejects a finished source or destination', () => {
+    expect(() =>
+      moveTaskBetweenContainers(finished(task('BD-1', 'todo', 100)), release(), 'BD-1', {
+        newStatus: 'todo',
+        beforeTaskId: null,
+      }),
+    ).toThrow(/out of a finished/);
+    expect(() =>
+      moveTaskBetweenContainers(release(task('BD-2', 'todo', 100)), finished(), 'BD-2', {
+        newStatus: 'todo',
+        beforeTaskId: null,
+      }),
+    ).toThrow(/into a finished/);
+  });
+});

--- a/packages/core/src/board-ops.ts
+++ b/packages/core/src/board-ops.ts
@@ -31,6 +31,13 @@ export const emptyBacklog = (): Backlog => ({
   tasks: [],
 });
 
+// A finished release is archived: the product treats its tasks as read-only and
+// forbids scheduling new work into it. These invariants live here so every shell
+// (UI, CLI, …) enforces them without re-implementing the rule. `status` only
+// exists on a Release frontmatter, so the `in` check narrows the union safely.
+const isFinishedRelease = (container: Container): boolean =>
+  'status' in container.frontmatter && container.frontmatter.status === 'finished';
+
 const ORDER_STEP = 100;
 
 const WINDOWS_FORBIDDEN_CHARS = '<>:"/\\|?*';
@@ -158,6 +165,9 @@ export const startRelease = (
   release: Release,
   existing: readonly Release[],
 ): Release => {
+  if (release.frontmatter.status !== 'future') {
+    throw new Error('Only a future release can be started');
+  }
   const current = existing.find(
     (r) => r.frontmatter.status === 'current' && r.filename !== release.filename,
   );
@@ -267,6 +277,9 @@ export const createTask = <C extends Container>(
   config: BoardConfig,
   input: NewTaskInput,
 ): { container: C; config: BoardConfig; task: Task } => {
+  if (isFinishedRelease(container)) {
+    throw new Error('Cannot create a task in a finished release');
+  }
   const { id, config: nextConfig } = nextTaskId(config);
   const order = lastOrderInContainer(container.tasks) + ORDER_STEP;
   const task: Task = {
@@ -300,6 +313,9 @@ export const editTask = <C extends Container>(
   taskId: string,
   patch: TaskPatch,
 ): C => {
+  if (isFinishedRelease(container)) {
+    throw new Error('Cannot edit a task in a finished release');
+  }
   const current = findTask(container.tasks, taskId);
   const workingTasks =
     patch.status !== undefined && patch.status !== current.frontmatter.status
@@ -344,30 +360,41 @@ export const editEpic = (epic: Epic, patch: EpicPatch): Epic => ({
   },
 });
 
-export const deleteTask = <C extends Container>(container: C, taskId: string): C =>
-  replaceTasks(
+export const deleteTask = <C extends Container>(container: C, taskId: string): C => {
+  if (isFinishedRelease(container)) {
+    throw new Error('Cannot delete a task in a finished release');
+  }
+  return replaceTasks(
     container,
     container.tasks.filter((t) => t.frontmatter.id !== taskId),
   );
+};
 
 export const changeTaskStatus = <C extends Container>(
   container: C,
   taskId: string,
   newStatus: TaskStatus,
-): C =>
-  replaceTasks(
+): C => {
+  if (isFinishedRelease(container)) {
+    throw new Error('Cannot change the status of a task in a finished release');
+  }
+  return replaceTasks(
     container,
     placeTaskInContainer(container.tasks, taskId, {
       status: newStatus,
       beforeTaskId: null,
     }),
   );
+};
 
 export const reorderTask = <C extends Container>(
   container: C,
   taskId: string,
   beforeTaskId: string | null,
 ): C => {
+  if (isFinishedRelease(container)) {
+    throw new Error('Cannot reorder a task in a finished release');
+  }
   const task = findTask(container.tasks, taskId);
   return replaceTasks(
     container,
@@ -382,8 +409,12 @@ export const moveTaskInContainer = <C extends Container>(
   container: C,
   taskId: string,
   args: { status: TaskStatus; beforeTaskId: string | null },
-): C =>
-  replaceTasks(container, placeTaskInContainer(container.tasks, taskId, args));
+): C => {
+  if (isFinishedRelease(container)) {
+    throw new Error('Cannot move a task in a finished release');
+  }
+  return replaceTasks(container, placeTaskInContainer(container.tasks, taskId, args));
+};
 
 export type DestEpic =
   | { kind: 'preserve' }
@@ -416,6 +447,12 @@ export const moveTaskBetweenContainers = <S extends Container, D extends Contain
   taskId: string,
   args: MoveAcrossArgs,
 ): { source: S; dest: D } => {
+  if (isFinishedRelease(source)) {
+    throw new Error('Cannot move a task out of a finished release');
+  }
+  if (isFinishedRelease(dest)) {
+    throw new Error('Cannot move a task into a finished release');
+  }
   const task = findTask(source.tasks, taskId);
   const epicAction: DestEpic = args.destEpic ?? { kind: 'preserve' };
   const updated: Task = {
@@ -599,6 +636,9 @@ export interface CompleteReleaseResult {
 export const completeRelease = (
   input: CompleteReleaseContainers,
 ): CompleteReleaseResult => {
+  if (input.release.frontmatter.status !== 'current') {
+    throw new Error('Only the current release can be completed');
+  }
   const unfinished = input.release.tasks
     .filter((t) => t.frontmatter.status !== 'done')
     .sort((a, b) => a.frontmatter.order - b.frontmatter.order);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,22 @@ importers:
         specifier: ^8.18.0
         version: 8.59.2(eslint@9.39.4)(typescript@5.9.3)
 
+  packages/cli:
+    dependencies:
+      '@boardown/core':
+        specifier: workspace:*
+        version: link:../core
+    devDependencies:
+      '@types/node':
+        specifier: ^20.17.10
+        version: 20.19.39
+      esbuild:
+        specifier: ^0.24.0
+        version: 0.24.2
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@20.19.39)
+
   packages/core:
     dependencies:
       gray-matter:


### PR DESCRIPTION
## What

A `packages/cli` shell next to `web` / `vscode` / `electron` — a command-line
interface for a board, aimed at letting **agents and scripts** drive it, with a
human-friendly mode too. Consumes `@boardown/core`'s public API and implements
the `FsAdapter` over `node:fs/promises`. Post-MVP in spirit (like the Electron
shell).

## ⚠️ One change reaches into `packages/core` — please review separately

Commit `feat(core): enforce release lifecycle and archive invariants` is the only
change outside the new package. board-ops were pure and enforced **no process
rules**, so any shell going straight to them could do things the UI forbids
(complete a non-current release, start a finished one, edit/move a task in a
finished release). Rather than re-implement those rules in every shell, this puts
them in the kernel so all shells get them:

- `startRelease` rejects a non-future release; `completeRelease` rejects a
  non-current one.
- A finished release is archived: creating, editing, status-changing, reordering,
  deleting, or moving a task into/out of it now throws.

The UI never triggers these (its affordances are already gated), so it's defense
in depth — **UI behavior is unchanged**, and `pnpm test` for `core` and `ui` is
green. Happy to drop this back into the CLI shell if you'd rather keep the kernel
free of process rules — just say so.

## Commands

```
board                  Print the whole board.
init                   Create a .boardown/ board here.
task get <id>          Show a task and where it lives.
task add <title>       Create a task (--type --status --epic --release --description).
task edit <id>         Edit a task; also moves it: --release/--no-release (in/out of a
                       release) and --epic/--no-epic (reassign epic). No separate "move".
task status <id> <s>   Change a task status.
task reorder <id>      Change priority (--before/--after <id> | --up | --down).
task rm <id>           Delete a task.
release add/start/done Release lifecycle (done redistributes open tasks; --into to carry over).
release get/list/current  Inspect / list releases; show the current one.
epic add/edit/get/list    Manage and inspect epics.
schema                 Machine-readable contract of enums + command grammar.
```

`task edit` mirrors the app's edit dialog: changing the release moves the task in
or out of a release; changing the epic reassigns it (which physically relocates a
backlog/epic task to the epic file — the backlog serializer strips epic tags — but
just retags a task already in a release). This matches `store.updateTask`, so
there's no standalone `move` command.

## Output (please review the conventions)

JSON envelope when stdout is not a TTY (or `--json`); human-readable otherwise:

```jsonc
{ "ok": true,  "command": "task add", "data": { /* ... */ } }
{ "ok": false, "command": "task add", "error": { "code": "EPIC_NOT_FOUND", "message": "..." } }
```

Exit codes `0`/`1`/`2`. `schema` lets an agent read the contract instead of
guessing. There was no prior CLI, so this PR *introduces* the envelope shape,
error `code`s, and `schema` grammar — the most opinionated parts; happy to adjust.

## Install

`packages/cli` is `private` (like the other shells). For local global use:

```bash
pnpm --filter @boardown/cli build
cd packages/cli && pnpm link --global
boardown --help
```

## Tests & gates

`pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test` all green across the repo
(core 157, ui 61, cli ~37, electron 37). CLI tests cover arg parsing, the Node
`FsAdapter` (path guard, file/dir filtering, external-change guard), board
discovery, and full command integration including the process invariants and the
edit-based relocations.

## Deliberately not included

Deleting a release/epic and editing an epic's color — no such ops exist in
`packages/core`, so they'd be additional kernel changes; left for your call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
