### PR TITLE
feat(cli): add task checklist and notes commands

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -16,6 +16,8 @@ boardown task add <title>       Create a task (--type --status --epic --release 
 boardown task edit <id>         Edit a task (--title --description --type --status --epic --no-epic).
 boardown task status <id> <s>   Change a task status (todo | in-progress | done).
 boardown task rm <id>           Delete a task.
+boardown task checklist <op>    Checklist item: add | done | undone | edit | rm (on <id>).
+boardown task notes <op>        Note: add | edit | rm (on <id>).
 boardown schema                 Print the machine-readable command/enum contract.
 ```
 

--- a/packages/cli/src/app.ts
+++ b/packages/cli/src/app.ts
@@ -30,6 +30,8 @@ Commands:
   task status <id> <s>   Change a task status (todo | in-progress | done).
   task reorder <id>      Change priority (--before | --after <id> | --up | --down).
   task rm <id>           Delete a task.
+  task checklist <op>    Checklist item: add | done | undone | edit | rm (on <id>).
+  task notes <op>        Note: add | edit | rm (on <id>).
   release get <ref>      Show one release and its tasks.
   release list           List releases.
   release current        Show the current release and its tasks.

--- a/packages/cli/src/commands/commands.test.ts
+++ b/packages/cli/src/commands/commands.test.ts
@@ -1,7 +1,15 @@
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import type { Backlog, BoardConfig, Epic, Release, Task } from '@boardown/core';
+import type {
+  Backlog,
+  BoardConfig,
+  ChecklistItem,
+  Epic,
+  Note,
+  Release,
+  Task,
+} from '@boardown/core';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { parseArgs } from '../args';
 import { loadBoardOrThrow } from '../persistence';
@@ -92,6 +100,80 @@ describe('cli commands (integration)', () => {
     await expect(
       taskCommand(parseArgs(['task', 'add', 'X', '--epic', 'ghost']), ctx),
     ).rejects.toThrow(/epic/i);
+  });
+
+  it('checklist add → done → undone → edit → rm round-trips', async () => {
+    await initCommand(parseArgs(['init', '--id-prefix', 'TS']), ctx);
+    await taskCommand(parseArgs(['task', 'add', 'Has checklist']), ctx);
+
+    const add = await taskCommand(parseArgs(['task', 'checklist', 'add', 'TS-1', 'First item']), ctx);
+    const added = add.data as { task: Task; item: ChecklistItem };
+    expect(added.item.id).toBe('c1');
+    expect(added.item.done).toBe(false);
+    expect(added.task.frontmatter.checklist).toHaveLength(1);
+
+    await taskCommand(parseArgs(['task', 'checklist', 'add', 'TS-1', 'Second item']), ctx);
+
+    const checkedDone = await taskCommand(parseArgs(['task', 'checklist', 'done', 'TS-1', 'c1']), ctx);
+    const afterDone = (checkedDone.data as { task: Task }).task;
+    expect(afterDone.frontmatter.checklist?.find((i) => i.id === 'c1')?.done).toBe(true);
+
+    // alias `check` + idempotent undone
+    const checkedUndone = await taskCommand(parseArgs(['task', 'check', 'undone', 'TS-1', 'c1']), ctx);
+    const afterUndone = (checkedUndone.data as { task: Task }).task;
+    expect(afterUndone.frontmatter.checklist?.find((i) => i.id === 'c1')?.done).toBe(false);
+
+    await taskCommand(parseArgs(['task', 'checklist', 'edit', 'TS-1', 'c1', 'Renamed item']), ctx);
+    const removed = await taskCommand(parseArgs(['task', 'checklist', 'rm', 'TS-1', 'c2']), ctx);
+    const afterRm = (removed.data as { task: Task; removed: string }).task;
+    expect((removed.data as { removed: string }).removed).toBe('c2');
+    expect(afterRm.frontmatter.checklist).toHaveLength(1);
+    expect(afterRm.frontmatter.checklist?.[0]?.id).toBe('c1');
+    expect(afterRm.frontmatter.checklist?.[0]?.text).toBe('Renamed item');
+  });
+
+  it('notes add → edit → rm round-trips', async () => {
+    await initCommand(parseArgs(['init', '--id-prefix', 'TS']), ctx);
+    await taskCommand(parseArgs(['task', 'add', 'Has notes']), ctx);
+
+    const add = await taskCommand(parseArgs(['task', 'notes', 'add', 'TS-1', 'A thought']), ctx);
+    const added = add.data as { task: Task; note: Note };
+    expect(added.note.id).toBe('n1');
+    expect(Number.isNaN(Date.parse(added.note.createdAt))).toBe(false);
+    expect(added.task.frontmatter.notes).toHaveLength(1);
+
+    // alias `note`
+    await taskCommand(parseArgs(['task', 'note', 'add', 'TS-1', 'Another thought']), ctx);
+    await taskCommand(parseArgs(['task', 'notes', 'edit', 'TS-1', 'n1', 'Edited thought']), ctx);
+    const removed = await taskCommand(parseArgs(['task', 'notes', 'rm', 'TS-1', 'n2']), ctx);
+    const afterRm = (removed.data as { task: Task }).task;
+    expect(afterRm.frontmatter.notes).toHaveLength(1);
+    expect(afterRm.frontmatter.notes?.[0]?.id).toBe('n1');
+    expect(afterRm.frontmatter.notes?.[0]?.text).toBe('Edited thought');
+  });
+
+  it('checklist/notes ops reject a missing item with ITEM_NOT_FOUND', async () => {
+    await initCommand(parseArgs(['init', '--id-prefix', 'TS']), ctx);
+    await taskCommand(parseArgs(['task', 'add', 'T']), ctx);
+    await expect(
+      taskCommand(parseArgs(['task', 'checklist', 'done', 'TS-1', 'c9']), ctx),
+    ).rejects.toMatchObject({ code: 'ITEM_NOT_FOUND' });
+    await expect(
+      taskCommand(parseArgs(['task', 'notes', 'rm', 'TS-1', 'n9']), ctx),
+    ).rejects.toMatchObject({ code: 'ITEM_NOT_FOUND' });
+  });
+
+  it('task get human output lists checklist and notes with ids', async () => {
+    await initCommand(parseArgs(['init', '--id-prefix', 'TS']), ctx);
+    await taskCommand(parseArgs(['task', 'add', 'T']), ctx);
+    await taskCommand(parseArgs(['task', 'checklist', 'add', 'TS-1', 'Buy milk']), ctx);
+    await taskCommand(parseArgs(['task', 'notes', 'add', 'TS-1', 'Remember this']), ctx);
+    const get = await taskCommand(parseArgs(['task', 'get', 'TS-1']), ctx);
+    expect(get.human).toContain('Checklist (0/1)');
+    expect(get.human).toContain('c1');
+    expect(get.human).toContain('Buy milk');
+    expect(get.human).toContain('Notes (1)');
+    expect(get.human).toContain('Remember this');
   });
 
   it('reports NO_BOARD when no board exists', async () => {

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -17,6 +17,8 @@ const DESCRIPTOR = {
     status: 'one of taskStatuses',
     epic: 'optional epic slug',
     order: 'number, managed by boardown',
+    checklist: 'optional array of { id, text, done }; managed via `task checklist`',
+    notes: 'optional array of { id, text, createdAt }; managed via `task notes`',
   },
   commands: [
     { name: 'board', usage: 'boardown board [--json]', summary: 'Print the whole board.' },
@@ -50,6 +52,18 @@ const DESCRIPTOR = {
       summary: "Change a task's priority (order) within its container.",
     },
     { name: 'task rm', usage: 'boardown task rm <id>', summary: 'Delete a task.' },
+    {
+      name: 'task checklist',
+      usage:
+        'boardown task checklist (add <id> <text> | done <id> <item> | undone <id> <item> | edit <id> <item> <text> | rm <id> <item>)',
+      summary: 'Manage a task checklist (alias: check). Item ids are c1, c2, …',
+    },
+    {
+      name: 'task notes',
+      usage:
+        'boardown task notes (add <id> <text> | edit <id> <note> <text> | rm <id> <note>)',
+      summary: 'Manage task notes (alias: note). Note ids are n1, n2, …, each with a createdAt timestamp.',
+    },
     {
       name: 'release get',
       usage: 'boardown release get <file|slug>',

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -5,13 +5,17 @@ import {
   editTask,
   emptyBacklog,
   moveTaskBetweenContainers,
+  nextChecklistItemId,
+  nextNoteId,
   reorderTask,
   TASK_STATUSES,
   TASK_TYPES,
   type BoardSnapshot,
+  type ChecklistItem,
   type DestEpic,
   type FsAdapter,
   type NewTaskInput,
+  type Note,
   type ParseProblem,
   type Task,
   type TaskPatch,
@@ -50,10 +54,16 @@ export const taskCommand: CommandHandler = (args, ctx) => {
     case 'remove':
     case 'delete':
       return taskRm(args, ctx);
+    case 'checklist':
+    case 'check':
+      return taskChecklist(args, ctx);
+    case 'notes':
+    case 'note':
+      return taskNotes(args, ctx);
     default:
       throw new CliError(
         'USAGE',
-        `Unknown task subcommand "${sub ?? ''}". Use: get | add | edit | status | reorder | rm.`,
+        `Unknown task subcommand "${sub ?? ''}". Use: get | add | edit | status | reorder | rm | checklist | notes.`,
         2,
       );
   }
@@ -367,11 +377,24 @@ async function taskStatus(args: ParsedArgs, ctx: CommandContext): Promise<Comman
   return { data: { task }, human: `${id} → ${status}.`, ...problemsField(problems) };
 }
 
+const renderChecklist = (items: readonly ChecklistItem[] | undefined): string => {
+  if (items === undefined || items.length === 0) return '';
+  const done = items.filter((it) => it.done).length;
+  const lines = items.map((it) => `  ${it.id}  [${it.done ? 'x' : ' '}] ${it.text}`).join('\n');
+  return `\n\nChecklist (${done}/${items.length}):\n${lines}`;
+};
+
+const renderNotes = (notes: readonly Note[] | undefined): string => {
+  if (notes === undefined || notes.length === 0) return '';
+  const lines = notes.map((n) => `  ${n.id}  ${n.createdAt}\n    ${n.text}`).join('\n');
+  return `\n\nNotes (${notes.length}):\n${lines}`;
+};
+
 const renderTask = (task: Task, kind: string, file: string): string => {
   const fm = task.frontmatter;
   const epic = fm.epic !== undefined ? `  epic:${fm.epic}` : '';
   const body = task.description.length > 0 ? `\n\n${task.description}` : '';
-  return `${fm.id}  [${fm.type}/${fm.status}]${epic}  (${kind}: ${file})\n${task.title}${body}`;
+  return `${fm.id}  [${fm.type}/${fm.status}]${epic}  (${kind}: ${file})\n${task.title}${body}${renderChecklist(fm.checklist)}${renderNotes(fm.notes)}`;
 };
 
 async function taskGet(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
@@ -514,4 +537,241 @@ async function taskRm(args: ParsedArgs, ctx: CommandContext): Promise<CommandOut
     human: `Removed ${id} from ${updated.filename}.`,
     ...problemsField(problems),
   };
+}
+
+// Shared read-modify-write for checklist / notes sub-ops: load the board, find
+// the task, let `build` turn it into a TaskPatch, then editTask + write. core
+// has no granular note/item mutators — both arrays are replaced wholesale via
+// editTask, which also enforces the finished-release guard (mapped to ARCHIVED
+// by applyOp, like every other task mutation).
+async function mutateTask(
+  ctx: CommandContext,
+  taskId: string | undefined,
+  usage: string,
+  build: (task: Task) => { patch: TaskPatch; human: string; extra?: Record<string, unknown> },
+): Promise<CommandOutput> {
+  if (taskId === undefined) {
+    throw new CliError('USAGE', usage, 2);
+  }
+  const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
+  const { fs, snapshot, problems } = await loadBoardOrThrow(root);
+  const location = locateTask(snapshot, taskId);
+  if (location === null) {
+    throw new CliError('TASK_NOT_FOUND', `No task "${taskId}".`);
+  }
+  const task = location.container.tasks.find((t) => t.frontmatter.id === taskId);
+  if (task === undefined) {
+    throw new CliError('TASK_NOT_FOUND', `No task "${taskId}".`);
+  }
+
+  const { patch, human, extra } = build(task);
+  const edited = applyOp(() => editTask(location.container, taskId, patch));
+  await writeContainer(fs, { kind: location.kind, container: edited });
+  const updated = edited.tasks.find((t) => t.frontmatter.id === taskId);
+
+  return {
+    data: { task: updated, file: edited.filename, ...(extra ?? {}) },
+    human,
+    ...problemsField(problems),
+  };
+}
+
+function requireText(value: string | undefined, usage: string): string {
+  const text = value?.trim();
+  if (text === undefined || text.length === 0) {
+    throw new CliError('USAGE', usage, 2);
+  }
+  return text;
+}
+
+function requireChecklistItem(task: Task, itemId: string | undefined, usage: string): ChecklistItem {
+  if (itemId === undefined) {
+    throw new CliError('USAGE', usage, 2);
+  }
+  const item = (task.frontmatter.checklist ?? []).find((it) => it.id === itemId);
+  if (item === undefined) {
+    throw new CliError('ITEM_NOT_FOUND', `No checklist item "${itemId}" on ${task.frontmatter.id}.`);
+  }
+  return item;
+}
+
+function requireNote(task: Task, noteId: string | undefined, usage: string): Note {
+  if (noteId === undefined) {
+    throw new CliError('USAGE', usage, 2);
+  }
+  const note = (task.frontmatter.notes ?? []).find((n) => n.id === noteId);
+  if (note === undefined) {
+    throw new CliError('ITEM_NOT_FOUND', `No note "${noteId}" on ${task.frontmatter.id}.`);
+  }
+  return note;
+}
+
+function taskChecklist(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
+  const op = args.positionals[2];
+  const taskId = args.positionals[3];
+  switch (op) {
+    case 'add':
+      return checklistAdd(args, ctx, taskId);
+    case 'done':
+      return checklistSetDone(args, ctx, taskId, true);
+    case 'undone':
+      return checklistSetDone(args, ctx, taskId, false);
+    case 'edit':
+      return checklistEdit(args, ctx, taskId);
+    case 'rm':
+    case 'remove':
+      return checklistRm(args, ctx, taskId);
+    default:
+      throw new CliError(
+        'USAGE',
+        `Unknown checklist subcommand "${op ?? ''}". Use: add | done | undone | edit | rm.`,
+        2,
+      );
+  }
+}
+
+function checklistAdd(
+  args: ParsedArgs,
+  ctx: CommandContext,
+  taskId: string | undefined,
+): Promise<CommandOutput> {
+  const usage = 'Usage: boardown task checklist add <task-id> <text>.';
+  const text = requireText(args.positionals[4], usage);
+  return mutateTask(ctx, taskId, usage, (task) => {
+    const items = task.frontmatter.checklist ?? [];
+    const item: ChecklistItem = { id: nextChecklistItemId(items), text, done: false };
+    return {
+      patch: { checklist: [...items, item] },
+      human: `Added checklist item ${item.id} to ${task.frontmatter.id}.`,
+      extra: { item },
+    };
+  });
+}
+
+function checklistSetDone(
+  args: ParsedArgs,
+  ctx: CommandContext,
+  taskId: string | undefined,
+  done: boolean,
+): Promise<CommandOutput> {
+  const usage = `Usage: boardown task checklist ${done ? 'done' : 'undone'} <task-id> <item-id>.`;
+  const itemId = args.positionals[4];
+  return mutateTask(ctx, taskId, usage, (task) => {
+    requireChecklistItem(task, itemId, usage);
+    const items = task.frontmatter.checklist ?? [];
+    return {
+      patch: { checklist: items.map((it) => (it.id === itemId ? { ...it, done } : it)) },
+      human: `${itemId} on ${task.frontmatter.id} → ${done ? 'done' : 'not done'}.`,
+    };
+  });
+}
+
+function checklistEdit(
+  args: ParsedArgs,
+  ctx: CommandContext,
+  taskId: string | undefined,
+): Promise<CommandOutput> {
+  const usage = 'Usage: boardown task checklist edit <task-id> <item-id> <text>.';
+  const itemId = args.positionals[4];
+  const text = requireText(args.positionals[5], usage);
+  return mutateTask(ctx, taskId, usage, (task) => {
+    requireChecklistItem(task, itemId, usage);
+    const items = task.frontmatter.checklist ?? [];
+    return {
+      patch: { checklist: items.map((it) => (it.id === itemId ? { ...it, text } : it)) },
+      human: `Edited checklist item ${itemId} on ${task.frontmatter.id}.`,
+    };
+  });
+}
+
+function checklistRm(
+  args: ParsedArgs,
+  ctx: CommandContext,
+  taskId: string | undefined,
+): Promise<CommandOutput> {
+  const usage = 'Usage: boardown task checklist rm <task-id> <item-id>.';
+  const itemId = args.positionals[4];
+  return mutateTask(ctx, taskId, usage, (task) => {
+    requireChecklistItem(task, itemId, usage);
+    const items = task.frontmatter.checklist ?? [];
+    return {
+      patch: { checklist: items.filter((it) => it.id !== itemId) },
+      human: `Removed checklist item ${itemId} from ${task.frontmatter.id}.`,
+      extra: { removed: itemId },
+    };
+  });
+}
+
+function taskNotes(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
+  const op = args.positionals[2];
+  const taskId = args.positionals[3];
+  switch (op) {
+    case 'add':
+      return noteAdd(args, ctx, taskId);
+    case 'edit':
+      return noteEdit(args, ctx, taskId);
+    case 'rm':
+    case 'remove':
+      return noteRm(args, ctx, taskId);
+    default:
+      throw new CliError(
+        'USAGE',
+        `Unknown notes subcommand "${op ?? ''}". Use: add | edit | rm.`,
+        2,
+      );
+  }
+}
+
+function noteAdd(
+  args: ParsedArgs,
+  ctx: CommandContext,
+  taskId: string | undefined,
+): Promise<CommandOutput> {
+  const usage = 'Usage: boardown task notes add <task-id> <text>.';
+  const text = requireText(args.positionals[4], usage);
+  return mutateTask(ctx, taskId, usage, (task) => {
+    const notes = task.frontmatter.notes ?? [];
+    const note: Note = { id: nextNoteId(notes), text, createdAt: new Date().toISOString() };
+    return {
+      patch: { notes: [...notes, note] },
+      human: `Added note ${note.id} to ${task.frontmatter.id}.`,
+      extra: { note },
+    };
+  });
+}
+
+function noteEdit(
+  args: ParsedArgs,
+  ctx: CommandContext,
+  taskId: string | undefined,
+): Promise<CommandOutput> {
+  const usage = 'Usage: boardown task notes edit <task-id> <note-id> <text>.';
+  const noteId = args.positionals[4];
+  const text = requireText(args.positionals[5], usage);
+  return mutateTask(ctx, taskId, usage, (task) => {
+    requireNote(task, noteId, usage);
+    const notes = task.frontmatter.notes ?? [];
+    return {
+      patch: { notes: notes.map((n) => (n.id === noteId ? { ...n, text } : n)) },
+      human: `Edited note ${noteId} on ${task.frontmatter.id}.`,
+    };
+  });
+}
+
+function noteRm(
+  args: ParsedArgs,
+  ctx: CommandContext,
+  taskId: string | undefined,
+): Promise<CommandOutput> {
+  const usage = 'Usage: boardown task notes rm <task-id> <note-id>.';
+  const noteId = args.positionals[4];
+  return mutateTask(ctx, taskId, usage, (task) => {
+    requireNote(task, noteId, usage);
+    const notes = task.frontmatter.notes ?? [];
+    return {
+      patch: { notes: notes.filter((n) => n.id !== noteId) },
+      human: `Removed note ${noteId} from ${task.frontmatter.id}.`,
+      extra: { removed: noteId },
+    };
+  });
 }


### PR DESCRIPTION
## What

Adds CLI commands for the **checklist** and **notes** task features that already
landed in the UI/core, so a board can be driven fully from the agent-facing CLI.

New `task` subcommands:

| Command | Alias | Purpose |
|---|---|---|
| `task checklist add <id> <text>` | `check` | Add a checklist item (returns the new item) |
| `task checklist done <id> <item-id>` | | Mark an item done (idempotent) |
| `task checklist undone <id> <item-id>` | | Mark an item not done (idempotent) |
| `task checklist edit <id> <item-id> <text>` | | Change an item's text |
| `task checklist rm <id> <item-id>` | | Remove an item |
| `task notes add <id> <text>` | `note` | Add a note (returns the new note) |
| `task notes edit <id> <note-id> <text>` | | Change a note's text |
| `task notes rm <id> <note-id>` | | Remove a note |

`task get`'s human output now lists checklist items (`[x]`/`[ ]` + ids, a
`done/total` count) and notes (id + `createdAt` + text), so an agent can read the
ids it needs for follow-up commands without parsing JSON.

## How

Implemented entirely in the CLI shell — **`core` and `ui` are untouched**. core
already stores `checklist` and `notes` as optional task-frontmatter arrays, and
`editTask` already accepts them in its `TaskPatch` (whole-array replace). There
are no granular note/item mutators in core, so each command is a small
read-modify-write over the array and writes it back through `editTask`, reusing
core's exported `nextChecklistItemId` / `nextNoteId` so item ids (`c1…`, `n1…`)
match what the UI generates. The finished-release read-only guard is inherited
automatically (mapped to the existing `ARCHIVED` error code).

Design notes:

- **`done` / `undone` are idempotent** (set, not toggle) — friendlier for
  scripted/agent use, where a retried command shouldn't silently flip state back.
- A missing item or note fails with a stable `ITEM_NOT_FOUND` error code; a
  missing argument is a `USAGE` error.
- `schema` and `--help` are updated so the machine-readable contract stays in
  sync.

## Scope

4 files, all in `packages/cli`: `commands/task.ts`, `commands/schema.ts`,
`app.ts`, `commands/commands.test.ts`.

## Verification

- `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test` — all green
  (4 new integration test blocks: checklist round-trip incl. alias, notes
  round-trip incl. alias, `ITEM_NOT_FOUND`, and `task get` human output).
- End-to-end smoke on a throwaway board through the built `dist/cli.cjs` bundle:
  both aliases work, the on-disk frontmatter is serialized in the same shape the
  UI/serializer writes (so the `.boardown/` data format stays consistent between
  CLI and UI), and the `ITEM_NOT_FOUND` path returns the expected envelope.
