### PR TITLE
feat: auto-refresh the board on external file changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`). If the workspace has no
 `.boardown/` folder yet, an onboarding screen walks you through creating the
 board.
 
+The open board refreshes itself when its `.boardown/` files change on disk —
+switching branches, pulling, editing a file, or running the CLI all update the
+board in place, without the Reload button. Turn it off with the
+`boardown.autoRefresh` setting.
+
 ### Desktop app
 
 Each [GitHub Release](https://github.com/grinev/boardown/releases) also ships a
@@ -83,6 +88,10 @@ To run anyway:
 
 On launch the app shows recent project folders and an **Open Folder…** button;
 pick a folder and the board loads from its `.boardown/`.
+
+The board refreshes itself when those files change on disk — from git, an
+editor, or the CLI — updating in place without the Reload button. Toggle it
+under **Settings → Auto-refresh on file changes** in the sidebar.
 
 ## Building the `.vsix` from sources
 

--- a/packages/electron/src/bridge.ts
+++ b/packages/electron/src/bridge.ts
@@ -35,6 +35,8 @@ export interface BootstrapState {
   // where the native menu bar is removed; false on macOS, which keeps its
   // system menu bar at the top of the screen.
   showMenuButton: boolean;
+  // Whether auto-refresh on external file changes is on, for the Settings panel.
+  autoRefresh: boolean;
 }
 
 // The surface exposed on window.boardown by the preload. The renderer talks to
@@ -63,9 +65,17 @@ export interface BoardownBridge {
   // Change the app-wide theme mode (persisted). The resolved value arrives via
   // `theme` / onThemeChange; the current mode is `themeChoice`.
   readonly setThemeChoice: (choice: ThemeChoice) => Promise<void>;
+  // Whether auto-refresh is on (initial state for the Settings checkbox).
+  readonly autoRefresh: boolean;
+  // Toggle auto-refresh on external file changes (persisted, applies to all
+  // open windows). Rejects/throws on a failed save so the UI can revert.
+  readonly setAutoRefresh: (enabled: boolean) => Promise<void>;
   readonly onBoardOpened: (listener: (folder: string) => void) => () => void;
   readonly onBoardClosed: (listener: () => void) => () => void;
   readonly onThemeChange: (listener: (theme: Theme) => void) => () => void;
+  // The board's .boardown/ files changed on disk outside this window (git, the
+  // CLI, another editor). The renderer refreshes in place; see Root.tsx.
+  readonly onBoardChanged: (listener: () => void) => () => void;
 }
 
 export const IPC = {
@@ -78,8 +88,10 @@ export const IPC = {
   removeRecent: 'boardown:remove-recent',
   getRecents: 'boardown:get-recents',
   setThemeChoice: 'boardown:set-theme-choice',
+  setAutoRefresh: 'boardown:set-auto-refresh',
   boardOpened: 'boardown:board-opened',
   boardClosed: 'boardown:board-closed',
+  boardChanged: 'boardown:board-changed',
   themeChanged: 'boardown:theme-changed',
 } as const;
 

--- a/packages/electron/src/main/board-fs.test.ts
+++ b/packages/electron/src/main/board-fs.test.ts
@@ -1,7 +1,7 @@
 import { promises as fsp } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { handleFsRequest, resolveTarget } from './board-fs';
 
 const ROOT = path.resolve('/tmp/boardown-test/.boardown');
@@ -91,5 +91,18 @@ describe('handleFsRequest', () => {
     await expect(
       handleFsRequest(root, { method: 'read', path: '../escape' }),
     ).rejects.toThrow(/Invalid path/);
+  });
+
+  it('calls onWrite with the absolute path on write, and never on read/stat/list', async () => {
+    const onWrite = vi.fn();
+    await handleFsRequest(root, { method: 'write', path: 'releases/r.md', content: 'hi' }, onWrite);
+    expect(onWrite).toHaveBeenCalledTimes(1);
+    expect(onWrite).toHaveBeenCalledWith(path.join(root, 'releases', 'r.md'));
+
+    onWrite.mockClear();
+    await handleFsRequest(root, { method: 'read', path: 'releases/r.md' }, onWrite);
+    await handleFsRequest(root, { method: 'stat', path: 'releases/r.md' }, onWrite);
+    await handleFsRequest(root, { method: 'list', path: 'releases' }, onWrite);
+    expect(onWrite).not.toHaveBeenCalled();
   });
 });

--- a/packages/electron/src/main/board-fs.ts
+++ b/packages/electron/src/main/board-fs.ts
@@ -31,7 +31,14 @@ function isENOENT(err: unknown): boolean {
 // throwing keeps Electron's IPC layer from logging a stack for every absent
 // file. The preload turns a null read back into the rejection FsAdapter.read
 // promises, so the renderer contract is unchanged.
-export async function handleFsRequest(boardRoot: string, req: FsRequest): Promise<unknown> {
+export async function handleFsRequest(
+  boardRoot: string,
+  req: FsRequest,
+  // Called with the absolute path after a successful write, so the caller can
+  // record its own writes and tell them apart from external changes in the
+  // file watcher (echo suppression). Kept here so board-fs stays fs-only.
+  onWrite?: (absPath: string) => void,
+): Promise<unknown> {
   const target = resolveTarget(boardRoot, req.path);
   if (target === null) {
     throw new Error(`Invalid path: ${req.path}`);
@@ -48,6 +55,7 @@ export async function handleFsRequest(boardRoot: string, req: FsRequest): Promis
     case 'write':
       await fsp.mkdir(path.dirname(target), { recursive: true });
       await fsp.writeFile(target, req.content ?? '', 'utf-8');
+      onWrite?.(target);
       return undefined;
     case 'list':
       try {

--- a/packages/electron/src/main/main.ts
+++ b/packages/electron/src/main/main.ts
@@ -1,4 +1,4 @@
-import { statSync } from 'node:fs';
+import { statSync, readdirSync, watch, type FSWatcher } from 'node:fs';
 import path from 'node:path';
 import {
   app,
@@ -45,8 +45,28 @@ interface BoardContext {
 }
 const boards = new Map<number, BoardContext>();
 
+// How long after the host writes a file its own watch event is ignored, so the
+// renderer's own saves don't bounce back as an "external change" refresh.
+const ECHO_WINDOW_MS = 2000;
+// Collapse a burst of changes (e.g. a `git checkout`) into a single refresh.
+const REFRESH_DEBOUNCE_MS = 200;
+
+// Per-window file watcher over the open board's .boardown/, keyed by webContents
+// id (parallel to `boards`). Present only while auto-refresh is on and a board is
+// open; recentWrites tracks the host's own writes for echo suppression.
+interface BoardWatcher {
+  watchers: FSWatcher[];
+  recentWrites: Map<string, number>;
+  debounceTimer?: ReturnType<typeof setTimeout> | undefined;
+}
+const boardWatchers = new Map<number, BoardWatcher>();
+
 // Persisted app settings (theme choice + window bounds), loaded on startup.
 let settings: Settings = { themeChoice: 'system' };
+
+// The native application menu, built once at startup. Used as the macOS system
+// menu bar and as the Win/Linux popup triggered by the ☰ button.
+let appMenu: Menu;
 
 function effectiveTheme(): Theme {
   if (settings.themeChoice === 'system') return nativeTheme.shouldUseDarkColors ? 'dark' : 'light';
@@ -88,6 +108,95 @@ function broadcastTheme(): void {
   }
 }
 
+function autoRefreshEnabled(): boolean {
+  // Absent means on; only an explicit false disables it.
+  return settings.autoRefresh !== false;
+}
+
+function disposeWatcher(id: number): void {
+  const bw = boardWatchers.get(id);
+  if (!bw) return;
+  clearTimeout(bw.debounceTimer);
+  for (const w of bw.watchers) w.close();
+  bw.recentWrites.clear();
+  boardWatchers.delete(id);
+}
+
+// (Re)build the per-window watcher for the board open in `window`: replaces any
+// existing one (board switch) and tears it down when auto-refresh is off.
+// .boardown/ has a fixed shallow layout (config.yaml + releases/ + epics/), so
+// rather than rely on recursive fs.watch — unreliable on Linux — we watch the
+// root and each first-level subdirectory explicitly.
+function applyWatcher(window: BrowserWindow): void {
+  const id = window.webContents.id;
+  disposeWatcher(id);
+  if (!autoRefreshEnabled()) return;
+  const ctx = boards.get(id);
+  if (!ctx) return;
+
+  const bw: BoardWatcher = { watchers: [], recentWrites: new Map() };
+  boardWatchers.set(id, bw);
+
+  const onEvent =
+    (dir: string) =>
+    (_event: string, filename: string | null): void => {
+      if (filename !== null) {
+        const abs = path.join(dir, filename);
+        const at = bw.recentWrites.get(abs);
+        if (at !== undefined) {
+          // The host's own write echoes back as a watch event — ignore it while
+          // fresh; let a stale entry fall through (and drop it).
+          if (Date.now() - at <= ECHO_WINDOW_MS) return;
+          bw.recentWrites.delete(abs);
+        }
+      }
+      clearTimeout(bw.debounceTimer);
+      bw.debounceTimer = setTimeout(() => {
+        bw.debounceTimer = undefined;
+        if (!window.isDestroyed()) window.webContents.send(IPC.boardChanged);
+      }, REFRESH_DEBOUNCE_MS);
+    };
+
+  const watchDir = (dir: string): void => {
+    try {
+      bw.watchers.push(watch(dir, onEvent(dir)));
+    } catch {
+      // A directory that isn't there (or vanished between readdir and watch) —
+      // skip it; the root watcher still catches it being created.
+    }
+  };
+
+  watchDir(ctx.boardRoot);
+  try {
+    for (const entry of readdirSync(ctx.boardRoot, { withFileTypes: true })) {
+      if (entry.isDirectory()) watchDir(path.join(ctx.boardRoot, entry.name));
+    }
+  } catch {
+    // Board root missing — nothing to watch until files appear.
+  }
+}
+
+// Persist first, mutate in-memory only on success (mirrors setThemeChoice), so a
+// failed save leaves main consistent and the renderer reverts its checkbox.
+// Applies to every open window immediately; the toggle lives in the renderer's
+// Settings panel.
+async function setAutoRefresh(enabled: boolean): Promise<void> {
+  const next: Settings = { ...settings, autoRefresh: enabled };
+  await saveSettings(next);
+  settings = next;
+  for (const window of BrowserWindow.getAllWindows()) applyWatcher(window);
+}
+
+function buildMenu(): void {
+  appMenu = buildAppMenu({
+    openFolder: (window) => void showOpenDialog(window),
+    closeBoard: (window) => closeBoard(window),
+  });
+  // macOS keeps the app menu as its system menu bar; Windows/Linux drop the bar
+  // and reach the same menu through the renderer's ☰ popup.
+  Menu.setApplicationMenu(process.platform === 'darwin' ? appMenu : null);
+}
+
 function setBoard(window: BrowserWindow, folder: string): void {
   boards.set(window.webContents.id, { folder, boardRoot: path.join(folder, BOARD_DIR) });
 }
@@ -98,6 +207,8 @@ async function openBoard(window: BrowserWindow, folder: string): Promise<void> {
   settings = { ...settings, lastFolder: folder };
   await addRecent(folder);
   void saveSettings(settings);
+  // Switch the watcher to the new board (replaces any prior one for this window).
+  applyWatcher(window);
   window.webContents.send(IPC.boardOpened, folder);
 }
 
@@ -105,6 +216,7 @@ async function openBoard(window: BrowserWindow, folder: string): Promise<void> {
 // stays in recents, so reopening it is one click away — but closing is
 // deliberate, so don't auto-reopen it on next launch.
 function closeBoard(window: BrowserWindow): void {
+  disposeWatcher(window.webContents.id);
   boards.delete(window.webContents.id);
   const { lastFolder, ...rest } = settings;
   settings = rest;
@@ -177,6 +289,7 @@ function createWindow(initialFolder: string | null): void {
     settings = { ...settings, lastFolder: initialFolder };
     void addRecent(initialFolder);
     void saveSettings(settings);
+    applyWatcher(window);
   }
 
   // Remember size/position across launches. Debounce resize/move (they fire in
@@ -195,6 +308,7 @@ function createWindow(initialFolder: string | null): void {
   });
 
   window.webContents.on('destroyed', () => {
+    disposeWatcher(id);
     boards.delete(id);
   });
 
@@ -224,7 +338,7 @@ function applySecurityHeaders(): void {
   });
 }
 
-function registerIpc(appMenu: Menu): void {
+function registerIpc(): void {
   ipcMain.on(IPC.bootstrap, (event) => {
     const ctx = boards.get(event.sender.id);
     const state: BootstrapState = {
@@ -232,6 +346,7 @@ function registerIpc(appMenu: Menu): void {
       themeChoice: settings.themeChoice,
       initialFolder: ctx?.folder ?? null,
       showMenuButton: process.platform !== 'darwin',
+      autoRefresh: autoRefreshEnabled(),
     };
     event.returnValue = state;
   });
@@ -244,7 +359,12 @@ function registerIpc(appMenu: Menu): void {
   ipcMain.handle(IPC.fs, async (event: IpcMainInvokeEvent, req: FsRequest) => {
     const ctx = boards.get(event.sender.id);
     if (!ctx) throw new Error('No board is open for this window');
-    return handleFsRequest(ctx.boardRoot, req);
+    const id = event.sender.id;
+    // Record the host's own writes so the watcher can tell them apart from
+    // external changes. No-op when this window has no watcher (auto-refresh off).
+    return handleFsRequest(ctx.boardRoot, req, (abs) => {
+      boardWatchers.get(id)?.recentWrites.set(abs, Date.now());
+    });
   });
 
   ipcMain.handle(IPC.pickFolder, async (event: IpcMainInvokeEvent) => {
@@ -263,6 +383,7 @@ function registerIpc(appMenu: Menu): void {
   ipcMain.handle(IPC.cancelBoard, async (event: IpcMainInvokeEvent) => {
     const ctx = boards.get(event.sender.id);
     if (!ctx) return;
+    disposeWatcher(event.sender.id);
     boards.delete(event.sender.id);
     if (settings.lastFolder === ctx.folder) {
       const { lastFolder, ...rest } = settings;
@@ -288,17 +409,20 @@ function registerIpc(appMenu: Menu): void {
     settings = next;
     broadcastTheme();
   });
+
+  ipcMain.handle(IPC.setAutoRefresh, async (_event: IpcMainInvokeEvent, enabled: boolean) => {
+    // IPC is an untrusted, stringly-typed boundary — validate before persisting.
+    if (typeof enabled !== 'boolean') return;
+    await setAutoRefresh(enabled);
+  });
 }
 
 app
   .whenReady()
   .then(async () => {
     settings = await loadSettings();
-    const appMenu = buildAppMenu({
-      openFolder: (window) => void showOpenDialog(window),
-      closeBoard: (window) => closeBoard(window),
-    });
-    registerIpc(appMenu);
+    buildMenu();
+    registerIpc();
     applySecurityHeaders();
     // macOS always shows its system menu bar, so keep the app menu there. On
     // Windows/Linux drop the menu bar entirely; the renderer's ☰ button pops

--- a/packages/electron/src/main/preload.ts
+++ b/packages/electron/src/main/preload.ts
@@ -17,6 +17,7 @@ const bridge: BoardownBridge = {
   themeChoice: bootstrap.themeChoice,
   initialFolder: bootstrap.initialFolder,
   showMenuButton: bootstrap.showMenuButton,
+  autoRefresh: bootstrap.autoRefresh,
   fs: {
     read: async (filePath) => {
       // Host returns null for a missing file (no IPC error log); restore the
@@ -38,6 +39,7 @@ const bridge: BoardownBridge = {
   removeRecent: (folder) => ipcRenderer.invoke(IPC.removeRecent, folder) as Promise<void>,
   getRecents: () => ipcRenderer.invoke(IPC.getRecents) as Promise<ProjectEntry[]>,
   setThemeChoice: (choice) => ipcRenderer.invoke(IPC.setThemeChoice, choice) as Promise<void>,
+  setAutoRefresh: (enabled) => ipcRenderer.invoke(IPC.setAutoRefresh, enabled) as Promise<void>,
   onBoardOpened: (listener) => {
     const handler = (_event: IpcRendererEvent, folder: string): void => listener(folder);
     ipcRenderer.on(IPC.boardOpened, handler);
@@ -47,6 +49,11 @@ const bridge: BoardownBridge = {
     const handler = (): void => listener();
     ipcRenderer.on(IPC.boardClosed, handler);
     return () => ipcRenderer.removeListener(IPC.boardClosed, handler);
+  },
+  onBoardChanged: (listener) => {
+    const handler = (): void => listener();
+    ipcRenderer.on(IPC.boardChanged, handler);
+    return () => ipcRenderer.removeListener(IPC.boardChanged, handler);
   },
   onThemeChange: (listener) => {
     const handler = (_event: IpcRendererEvent, theme: Theme): void => listener(theme);

--- a/packages/electron/src/main/settings.test.ts
+++ b/packages/electron/src/main/settings.test.ts
@@ -63,4 +63,17 @@ describe('settings', () => {
     await saveSettings({ themeChoice: 'dark' });
     expect(await fsp.readdir(state.userData)).toEqual(['settings.json']);
   });
+
+  it('leaves autoRefresh absent when not set (on by default)', async () => {
+    expect((await loadSettings()).autoRefresh).toBeUndefined();
+  });
+
+  it('keeps autoRefresh only when explicitly disabled', async () => {
+    await fsp.writeFile(
+      path.join(state.userData, 'settings.json'),
+      JSON.stringify({ themeChoice: 'system', autoRefresh: false }),
+      'utf-8',
+    );
+    expect((await loadSettings()).autoRefresh).toBe(false);
+  });
 });

--- a/packages/electron/src/main/settings.ts
+++ b/packages/electron/src/main/settings.ts
@@ -16,6 +16,9 @@ export interface Settings {
   windowMaximized?: boolean;
   // The project folder open when the app last closed, reopened on next launch.
   lastFolder?: string;
+  // Auto-refresh the board when its .boardown/ files change on disk. Absent =
+  // on; only an explicit false disables it.
+  autoRefresh?: boolean;
 }
 
 const CHOICES: readonly ThemeChoice[] = ['system', 'light', 'dark'];
@@ -58,6 +61,8 @@ export async function loadSettings(): Promise<Settings> {
       ...(bounds ? { windowBounds: bounds } : {}),
       ...(obj.windowMaximized === true ? { windowMaximized: true } : {}),
       ...(typeof obj.lastFolder === 'string' ? { lastFolder: obj.lastFolder } : {}),
+      // Default on: persist the field only when explicitly disabled.
+      ...(obj.autoRefresh === false ? { autoRefresh: false } : {}),
     };
   } catch {
     return { themeChoice: 'system' };

--- a/packages/electron/src/renderer/Root.tsx
+++ b/packages/electron/src/renderer/Root.tsx
@@ -5,7 +5,7 @@ import {
   useState,
   type PointerEvent as ReactPointerEvent,
 } from 'react';
-import { App } from '@boardown/ui';
+import { App, useBoardStore } from '@boardown/ui';
 import type { ProjectEntry, ThemeChoice } from '../bridge';
 import { Sidebar } from './Sidebar';
 import { folderName, suggestIdPrefix } from './project-name';
@@ -36,6 +36,7 @@ export function Root() {
   const [theme, setTheme] = useState(bridge.theme);
   const [projects, setProjects] = useState<ProjectEntry[]>([]);
   const [themeChoice, setThemeChoiceState] = useState<ThemeChoice>(bridge.themeChoice);
+  const [autoRefresh, setAutoRefreshState] = useState(bridge.autoRefresh);
 
   // App's defaultTheme only seeds a brand-new board's onboarding; it must stay
   // stable for each mount, or an OS theme change (which updates `theme`) would
@@ -94,6 +95,13 @@ export function Root() {
     [themeChoice],
   );
 
+  const chooseAutoRefresh = useCallback((enabled: boolean) => {
+    setAutoRefreshState(enabled);
+    // Revert on a failed save, so the checkbox never shows a state that wasn't
+    // persisted (previous value of a boolean toggle is just its negation).
+    void bridge.setAutoRefresh(enabled).catch(() => setAutoRefreshState(!enabled));
+  }, []);
+
   useEffect(() => {
     refreshProjects();
   }, [refreshProjects]);
@@ -111,6 +119,10 @@ export function Root() {
   );
   useEffect(() => bridge.onBoardClosed(() => setActiveFolder(null)), []);
   useEffect(() => bridge.onThemeChange(setTheme), []);
+  // The host signals when .boardown/ changed on disk outside this window; refresh
+  // the board in place via reloadSilent (no loading flash). A no-op when no board
+  // is mounted (store has no rawFs yet).
+  useEffect(() => bridge.onBoardChanged(() => void useBoardStore.getState().reloadSilent()), []);
 
   // With no board mounted, @boardown/ui's theme.css isn't loaded; keep the shell
   // palette in sync with the OS theme. Once App mounts it drives data-theme from
@@ -136,6 +148,8 @@ export function Root() {
         }}
         themeChoice={themeChoice}
         onThemeChoice={chooseTheme}
+        autoRefresh={autoRefresh}
+        onAutoRefresh={chooseAutoRefresh}
         showMenuButton={bridge.showMenuButton}
         onMenuButton={() => bridge.popupMenu()}
       />

--- a/packages/electron/src/renderer/Sidebar.module.css
+++ b/packages/electron/src/renderer/Sidebar.module.css
@@ -247,6 +247,19 @@
   gap: 4px;
 }
 
+.checkboxRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--shell-text);
+  cursor: pointer;
+}
+
+.checkboxRow input {
+  cursor: pointer;
+}
+
 .themeOption {
   flex: 1;
   padding: 6px 4px;

--- a/packages/electron/src/renderer/Sidebar.tsx
+++ b/packages/electron/src/renderer/Sidebar.tsx
@@ -12,6 +12,8 @@ interface SidebarProps {
   onRemove: (folder: string) => void;
   themeChoice: ThemeChoice;
   onThemeChoice: (choice: ThemeChoice) => void;
+  autoRefresh: boolean;
+  onAutoRefresh: (enabled: boolean) => void;
   showMenuButton: boolean;
   onMenuButton: () => void;
 }
@@ -31,6 +33,8 @@ export function Sidebar({
   onRemove,
   themeChoice,
   onThemeChoice,
+  autoRefresh,
+  onAutoRefresh,
   showMenuButton,
   onMenuButton,
 }: SidebarProps) {
@@ -126,6 +130,15 @@ export function Sidebar({
                 </button>
               ))}
             </div>
+            <span className={styles.settingsLabel}>Board</span>
+            <label className={styles.checkboxRow}>
+              <input
+                type="checkbox"
+                checked={autoRefresh}
+                onChange={(event) => onAutoRefresh(event.target.checked)}
+              />
+              Auto-refresh on file changes
+            </label>
           </div>
         )}
         <button

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,1 +1,2 @@
 export { App } from './App';
+export { useBoardStore } from './store';

--- a/packages/ui/src/store.ts
+++ b/packages/ui/src/store.ts
@@ -90,6 +90,7 @@ interface BoardState {
   settingsOpen: boolean;
   load: (fs: FsAdapter, defaultTheme?: Theme) => Promise<void>;
   reload: () => Promise<void>;
+  reloadSilent: () => Promise<void>;
   closeConflict: () => void;
   completeOnboarding: (input: OnboardingInput) => Promise<void>;
   setActiveTab: (tab: ActiveTab) => void;
@@ -297,6 +298,41 @@ export const useBoardStore = create<BoardState>((set, get) => ({
   reload: async () => {
     const { rawFs } = get();
     if (rawFs) await get().load(rawFs);
+  },
+
+  // Re-read the board and swap it in place without flipping status to
+  // 'loading', so an external change (git, the CLI, another editor) refreshes
+  // the view without flashing the loading screen. Only valid once a board is
+  // shown: outside 'ready', or when the board became invalid/absent on disk,
+  // fall back to the visible load() path — there a real problem should surface
+  // rather than silently keeping stale data.
+  reloadSilent: async () => {
+    const { rawFs, status } = get();
+    if (!rawFs) return;
+    if (status !== 'ready') {
+      await get().load(rawFs);
+      return;
+    }
+    try {
+      const result = await loadBoard(rawFs);
+      if (result.kind !== 'loaded') {
+        await get().load(rawFs);
+        return;
+      }
+      const guarded = createGuardedFs(rawFs, result.fileVersions, () =>
+        set({ conflictOpen: true }),
+      );
+      set({
+        fs: guarded,
+        snapshot: result.snapshot,
+        problems: result.snapshot.problems,
+        errorMessage: null,
+        conflictOpen: false,
+        theme: result.snapshot.config.theme ?? 'light',
+      });
+    } catch {
+      await get().load(rawFs);
+    }
   },
 
   closeConflict: () => set({ conflictOpen: false }),

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -45,6 +45,16 @@
           "group": "navigation"
         }
       ]
+    },
+    "configuration": {
+      "title": "boardown",
+      "properties": {
+        "boardown.autoRefresh": {
+          "type": "boolean",
+          "default": true,
+          "description": "Automatically refresh the board when its .boardown/ files change on disk (e.g. via git, the CLI, or external edits)."
+        }
+      }
     }
   },
   "scripts": {

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -3,6 +3,13 @@ import type { FsRequestMessage } from './messages';
 
 let panel: vscode.WebviewPanel | undefined;
 
+// How long after the host writes a file its own filesystem event is ignored, so
+// the webview's own saves don't bounce back as an "external change" refresh.
+const ECHO_WINDOW_MS = 2000;
+// Collapse a burst of changes (e.g. a `git checkout` touching many files) into a
+// single refresh.
+const REFRESH_DEBOUNCE_MS = 200;
+
 export function activate(context: vscode.ExtensionContext): void {
   const output = vscode.window.createOutputChannel('boardown');
   context.subscriptions.push(output);
@@ -37,17 +44,29 @@ export function activate(context: vscode.ExtensionContext): void {
 
       created.webview.html = getHtml(created.webview, context.extensionUri);
 
+      // Records fsPath -> timestamp of the host's own writes so the watcher can
+      // tell its own saves apart from genuinely external changes (see below).
+      const recentWrites = new Map<string, number>();
+
       created.webview.onDidReceiveMessage((message: { type?: string }) => {
         if (message.type === 'ready') {
           output.appendLine('webview ready');
           return;
         }
         if (message.type === 'fs-request') {
-          void handleFsRequest(created.webview, boardRootUri, message as FsRequestMessage);
+          void handleFsRequest(
+            created.webview,
+            boardRootUri,
+            message as FsRequestMessage,
+            recentWrites,
+          );
         }
       });
 
+      const autoRefresh = setupAutoRefresh(created, boardRootUri, recentWrites);
+
       created.onDidDispose(() => {
+        autoRefresh.dispose();
         panel = undefined;
       });
     }),
@@ -76,6 +95,7 @@ async function handleFsRequest(
   webview: vscode.Webview,
   boardRootUri: vscode.Uri,
   message: FsRequestMessage,
+  recentWrites: Map<string, number>,
 ): Promise<void> {
   const respond = (ok: boolean, result?: unknown, error?: string): void => {
     void webview.postMessage({ type: 'fs-response', id: message.id, ok, result, error });
@@ -96,6 +116,7 @@ async function handleFsRequest(
       }
       case 'write': {
         await vscode.workspace.fs.writeFile(target, new TextEncoder().encode(message.content ?? ''));
+        recentWrites.set(target.fsPath, Date.now());
         respond(true);
         return;
       }
@@ -130,6 +151,83 @@ async function handleFsRequest(
 
 function isFileNotFound(err: unknown): boolean {
   return err instanceof vscode.FileSystemError && err.code === 'FileNotFound';
+}
+
+// Watches the board's .boardown/ directory and tells the webview to refresh when
+// its files change on disk outside the board (git, the CLI, another editor).
+// Three concerns: (1) gate on the boardown.autoRefresh setting and react to it
+// being toggled live; (2) ignore the host's own writes — without this every save
+// from the board would echo back as an "external change"; (3) debounce bursts so
+// one `git checkout` is a single refresh, not one per file.
+function setupAutoRefresh(
+  panel: vscode.WebviewPanel,
+  boardRootUri: vscode.Uri,
+  recentWrites: Map<string, number>,
+): vscode.Disposable {
+  let watcher: vscode.FileSystemWatcher | undefined;
+  let debounceTimer: ReturnType<typeof setTimeout> | undefined;
+
+  const isOwnWrite = (fsPath: string): boolean => {
+    const at = recentWrites.get(fsPath);
+    if (at === undefined) return false;
+    if (Date.now() - at > ECHO_WINDOW_MS) {
+      recentWrites.delete(fsPath);
+      return false;
+    }
+    return true;
+  };
+
+  const scheduleRefresh = (): void => {
+    if (debounceTimer) clearTimeout(debounceTimer);
+    debounceTimer = setTimeout(() => {
+      debounceTimer = undefined;
+      void panel.webview.postMessage({ type: 'board-changed' });
+    }, REFRESH_DEBOUNCE_MS);
+  };
+
+  const onFsEvent = (uri: vscode.Uri): void => {
+    if (isOwnWrite(uri.fsPath)) return;
+    scheduleRefresh();
+  };
+
+  const startWatching = (): void => {
+    if (watcher) return;
+    watcher = vscode.workspace.createFileSystemWatcher(
+      new vscode.RelativePattern(boardRootUri, '**'),
+    );
+    watcher.onDidChange(onFsEvent);
+    watcher.onDidCreate(onFsEvent);
+    watcher.onDidDelete(onFsEvent);
+  };
+
+  const stopWatching = (): void => {
+    watcher?.dispose();
+    watcher = undefined;
+  };
+
+  const applySetting = (): void => {
+    const enabled = vscode.workspace
+      .getConfiguration('boardown')
+      .get<boolean>('autoRefresh', true);
+    if (enabled) startWatching();
+    else stopWatching();
+  };
+
+  applySetting();
+  const configSub = vscode.workspace.onDidChangeConfiguration((e) => {
+    if (e.affectsConfiguration('boardown.autoRefresh')) applySetting();
+  });
+
+  return {
+    dispose: (): void => {
+      if (debounceTimer) clearTimeout(debounceTimer);
+      stopWatching();
+      configSub.dispose();
+      // A path is only evicted from recentWrites when a matching watcher event
+      // arrives; entries that never get one would otherwise outlive the panel.
+      recentWrites.clear();
+    },
+  };
 }
 
 function themeName(kind: vscode.ColorThemeKind): 'light' | 'dark' {

--- a/packages/vscode/src/messages.ts
+++ b/packages/vscode/src/messages.ts
@@ -20,5 +20,12 @@ export interface ReadyMessage {
   type: 'ready';
 }
 
+// Pushed host→webview when .boardown/ changed on disk outside the webview, so
+// the board can refresh itself. Unlike FsResponseMessage it carries no id — it
+// is not a reply to a request but an unsolicited notification.
+export interface BoardChangedMessage {
+  type: 'board-changed';
+}
+
 export type WebviewToHost = FsRequestMessage | ReadyMessage;
-export type HostToWebview = FsResponseMessage;
+export type HostToWebview = FsResponseMessage | BoardChangedMessage;

--- a/packages/vscode/src/webview/main.tsx
+++ b/packages/vscode/src/webview/main.tsx
@@ -1,7 +1,7 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import type { Theme } from '@boardown/core';
-import { App } from '@boardown/ui';
+import { App, useBoardStore } from '@boardown/ui';
 import { VsCodeFsAdapter } from './VsCodeFsAdapter';
 import './webview.css';
 
@@ -39,5 +39,16 @@ createRoot(container).render(
     <App fs={new VsCodeFsAdapter(vscode)} defaultTheme={detectTheme()} />
   </StrictMode>,
 );
+
+// The host pushes 'board-changed' when .boardown/ changed on disk outside the
+// webview (git, the CLI, another editor). Refresh in place via reloadSilent so
+// the board updates without flashing the loading screen. Separate from the FS
+// request/response channel in VsCodeFsAdapter; both listeners filter by type.
+window.addEventListener('message', (event: MessageEvent) => {
+  const data = event.data as { type?: string } | null;
+  if (data?.type === 'board-changed') {
+    void useBoardStore.getState().reloadSilent();
+  }
+});
 
 vscode.postMessage({ type: 'ready' });


### PR DESCRIPTION
## What

Auto-refresh the board when its `.boardown/` files change on disk outside the
app — `git checkout`/`pull`, the CLI, an agent, or a hand edit — in both the
**VS Code extension** and the **Electron desktop shell**. The board updates in
place, without the manual Reload button and without flashing the loading screen.

## Why

Today the board is only re-read on the manual Reload button; the app learns
about external changes only when it next tries to write (the guard then raises
the conflict modal). In practice the files change out from under the board all
the time — especially in VS Code, where git, the integrated terminal (the CLI),
and agents are all right there. After a `git checkout` the open board silently
shows the previous branch's tasks until you remember to hit Reload.

This makes the common case "just work" while keeping the change small and
honest.

## How it works

Shared core (in `@boardown/ui`):

- New `reloadSilent()` store action: re-reads the board and swaps it in place
  **without** flipping `status` to `loading`, so there's no loading flash. It's
  used only from the `ready` state; outside it, or if the board became
  invalid/absent on disk, it falls back to the visible `load()` path so a real
  problem still surfaces. `useBoardStore` is now exported so a shell can trigger
  the refresh.

Each shell owns the file watching (a platform capability, like the FsAdapter):

- **VS Code** — `FileSystemWatcher` on `.boardown/**` in the host → pushes
  `board-changed` to the webview → `reloadSilent()`.
- **Electron** — a per-window `fs.watch` in the main process → pushes a
  `board-changed` IPC message → `reloadSilent()`.

Both suppress the **echo of their own writes** (the host both writes the files,
on behalf of the UI, and watches them): a just-written path is ignored for a
short window, so a save from the board never bounces back as an "external
change". A burst (a checkout touching many files) is debounced into one refresh.

One watcher over `.boardown/` covers every source of change — a hand edit, the
CLI, git, an agent — without any of them needing to know about a running UI.

**Why a board's own writes don't loop.** The host both writes `.boardown/` (on
behalf of the UI) and watches it, so a save would naively bounce back as an
"external change". Two properties prevent a cycle: (1) echo suppression
— a just-written path is ignored by the watcher for a short window, so a save
from the board never triggers a refresh; (2) `reloadSilent()` only *reads* and
swaps state in memory — it never writes, so even a missed suppression causes at most
one extra read, never a feedback loop. (In a multi-window desktop setup the
window that wrote suppresses its own echo, while another window on the same
folder does refresh — correctly, since for it the change is external — and
still can't loop, being read-only.)

## Design decisions & trade-offs

- **Watcher, not polling.** Event-driven, so an unchanged board is never
  re-read — no periodic flicker.
- **Silent refresh.** The existing `reload()` flips to `loading` first; that's
  the source of the flash, so the auto path is a separate in-place swap.
- **Off-switch.** Toggleable everywhere: VS Code via the `boardown.autoRefresh`
  setting; Electron via a checkbox in the Settings panel next to the theme
  picker. **Default on.** (Happy to flip the default if you'd rather it be
  opt-in.)
- **Electron: native `fs.watch`, no new dependency.** `.boardown/` has a fixed
  shallow layout (`config.yaml` + `releases/` + `epics/`), so instead of relying
  on recursive watching — unreliable on Linux — we watch the root and each
  first-level subdirectory explicitly. (chokidar would be the alternative if you
  prefer it; this keeps the dep list as-is.)
- **Electron: per-window lifecycle.** The watcher is keyed by `webContents` id
  and disposed in every teardown path (close board, cancel onboarding, board
  switch, window destroyed), so it never outlives its window.
- **`@boardown/ui` touched, but additively** — one new store action and one new
  export; existing `reload()` / conflict logic is untouched.

## Note: this changes a documented decision

`PRODUCT.md` / `CLAUDE.md` currently state *"no automatic refresh — re-reading
is the manual Reload button only"* and treat file-watching as a non-goal. This
PR diverges from that — your call whether it's a direction you want. I left the
spec and docs untouched rather than editing them here; if you do want this in,
should I update `PRODUCT.md` in this PR or track it as a follow-up?

## Testing

- `pnpm lint`, `pnpm typecheck`, `pnpm build`, `pnpm test` all green. Added unit
  coverage for the new Electron bits (settings `autoRefresh` parsing, the fs
  handler's `onWrite` callback).
- Manually verified the Electron shell end-to-end: opened the board, changed
  `.boardown/` via the CLI and via `git checkout` — the board refreshed in
  place with no flicker, and the Settings toggle disables/enables it and
  persists across restarts.
- **Not tested:** a live VS Code F5 / Extension Development Host session. The
  VS Code path is verified only statically (lint/typecheck/build) and by logic
  — worth a manual check before release. (The Electron path above was exercised
  live.)
- No new dependencies were added (native `fs.watch`), so there's nothing to
  vendor or revert on that front.

## Out of scope (possible follow-up)

A "busy" guard: if you're mid-edit in a task dialog when an external change
lands, the silent refresh still swaps the board underneath (a selected task id
could go stale). Deliberately left out here — it's the conflict/UX-busy layer,
a natural next step. The existing write-time conflict modal remains as the
safety net.
