### PR TITLE
feat(cli): add task list command with filters

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -29,6 +29,7 @@ boardown board                  Print the whole board.
 boardown init                   Create a .boardown/ board here (--id-prefix --project-name).
 
 boardown task get <id>          Show one task and where it lives.
+boardown task list              List/filter tasks (--status --type --epic --release --backlog --text).
 boardown task add <title>       Create a task (--type --status --epic --release --description).
 boardown task edit <id>         Edit a task; --release/--no-release and --epic/--no-epic also move it.
 boardown task status <id> <s>   Change a task status (todo | in-progress | done).
@@ -51,6 +52,12 @@ boardown epic edit <slug>       Edit an epic (--name --description).
 
 boardown schema                 Print the machine-readable command/enum contract.
 ```
+
+`task list` filters combine with AND; with no filters it prints every task.
+`--epic <slug>` matches both tasks stored in the epic file and tasks living in a
+release that carry that epic tag. `--release <ref>` takes a slug or filename,
+`--backlog` restricts to unreleased tasks, and `--text` is a case-insensitive
+match on title and description.
 
 The board is located by walking up from the current directory to a `.boardown/`
 folder (like git finds `.git`). Use `--data-dir <path>` to point at a specific

--- a/packages/cli/src/app.ts
+++ b/packages/cli/src/app.ts
@@ -25,6 +25,7 @@ Commands:
   board                  Print the whole board.
   init                   Create a .boardown/ board here.
   task get <id>          Show one task and where it lives.
+  task list              List/filter tasks (--status --type --epic --release --backlog --text).
   task add <title>       Create a task (--type --status --epic --release --description).
   task edit <id>         Edit a task; --release/--no-release also move it in/out of a release.
   task status <id> <s>   Change a task status (todo | in-progress | done).

--- a/packages/cli/src/args.ts
+++ b/packages/cli/src/args.ts
@@ -5,7 +5,16 @@ export interface ParsedArgs {
 
 // Flags that never take a value, so they don't swallow the following token
 // (e.g. `task add "T" --json` must keep "T" as a positional).
-const BOOLEAN_FLAGS = new Set(['json', 'help', 'dry-run', 'no-epic', 'no-release', 'up', 'down']);
+const BOOLEAN_FLAGS = new Set([
+  'json',
+  'help',
+  'dry-run',
+  'no-epic',
+  'no-release',
+  'up',
+  'down',
+  'backlog',
+]);
 
 export function parseArgs(argv: readonly string[]): ParsedArgs {
   const positionals: string[] = [];

--- a/packages/cli/src/commands/board.ts
+++ b/packages/cli/src/commands/board.ts
@@ -17,7 +17,7 @@ export const boardCommand: CommandHandler = async (_args, ctx) => {
   };
 };
 
-const statusMark = (task: Task): string => {
+export const statusMark = (task: Task): string => {
   switch (task.frontmatter.status) {
     case 'todo':
       return '○';

--- a/packages/cli/src/commands/commands.test.ts
+++ b/packages/cli/src/commands/commands.test.ts
@@ -15,7 +15,9 @@ import { parseArgs } from '../args';
 import { loadBoardOrThrow } from '../persistence';
 import type { CommandContext } from '../types';
 import { boardCommand } from './board';
+import { epicCommand } from './epic';
 import { initCommand } from './init';
+import { releaseCommand } from './release';
 import { taskCommand } from './task';
 
 interface BoardData {
@@ -193,6 +195,150 @@ describe('cli commands (integration)', () => {
 
     await expect(fs.write('epics/no_epic.md', 'whatever')).rejects.toMatchObject({
       code: 'CONFLICT',
+    });
+  });
+
+  describe('task list', () => {
+    // A known board: backlog (TS-1 bug/todo, TS-2 feature/done), epic file
+    // (TS-3 tech/todo, epic bug-audit), current release (TS-4 bug/todo, retagged
+    // into epic bug-audit while living in the release).
+    async function seed(): Promise<string> {
+      await initCommand(parseArgs(['init', '--id-prefix', 'TS', '--project-name', 'Demo']), ctx);
+      await epicCommand(parseArgs(['epic', 'add', 'Bug Audit']), ctx);
+      await taskCommand(parseArgs(['task', 'add', 'Alpha bug fix', '--type', 'bug']), ctx);
+      await taskCommand(parseArgs(['task', 'add', 'Beta feature', '--type', 'feature']), ctx);
+      await taskCommand(parseArgs(['task', 'status', 'TS-2', 'done']), ctx);
+      await taskCommand(
+        parseArgs(['task', 'add', 'Gamma tech', '--type', 'tech', '--epic', 'bug-audit']),
+        ctx,
+      );
+      const rel = await releaseCommand(parseArgs(['release', 'add', 'Active']), ctx);
+      const relFile = (rel.data as { release: { filename: string } }).release.filename;
+      await releaseCommand(parseArgs(['release', 'start', relFile]), ctx);
+      await taskCommand(
+        parseArgs(['task', 'add', 'Delta ship', '--type', 'bug', '--release', relFile]),
+        ctx,
+      );
+      await taskCommand(parseArgs(['task', 'edit', 'TS-4', '--epic', 'bug-audit']), ctx);
+      return relFile;
+    }
+
+    const listIds = (data: unknown): string[] =>
+      (data as { tasks: { task: Task }[] }).tasks.map((e) => e.task.frontmatter.id).sort();
+
+    it('lists every task with no filters', async () => {
+      await seed();
+      const out = await taskCommand(parseArgs(['task', 'list']), ctx);
+      expect(listIds(out.data)).toEqual(['TS-1', 'TS-2', 'TS-3', 'TS-4']);
+      expect((out.data as { count: number }).count).toBe(4);
+    });
+
+    it('each entry carries the task and its container location', async () => {
+      await seed();
+      const out = await taskCommand(parseArgs(['task', 'list', '--release', 'active']), ctx);
+      const tasks = (out.data as { tasks: { task: Task; in: { kind: string; file: string } }[] })
+        .tasks;
+      expect(tasks).toHaveLength(1);
+      expect(tasks[0]?.task.frontmatter.id).toBe('TS-4');
+      expect(tasks[0]?.in.kind).toBe('release');
+      expect(tasks[0]?.in.file).toBe('releases/active.md');
+    });
+
+    it('filters by status', async () => {
+      await seed();
+      expect(
+        listIds((await taskCommand(parseArgs(['task', 'list', '--status', 'todo']), ctx)).data),
+      ).toEqual(['TS-1', 'TS-3', 'TS-4']);
+      expect(
+        listIds((await taskCommand(parseArgs(['task', 'list', '--status', 'done']), ctx)).data),
+      ).toEqual(['TS-2']);
+    });
+
+    it('filters by type', async () => {
+      await seed();
+      expect(
+        listIds((await taskCommand(parseArgs(['task', 'list', '--type', 'bug']), ctx)).data),
+      ).toEqual(['TS-1', 'TS-4']);
+    });
+
+    it('filters by epic, catching both epic-file and release-tagged tasks', async () => {
+      await seed();
+      expect(
+        listIds((await taskCommand(parseArgs(['task', 'list', '--epic', 'bug-audit']), ctx)).data),
+      ).toEqual(['TS-3', 'TS-4']);
+    });
+
+    it('filters by release', async () => {
+      await seed();
+      expect(
+        listIds((await taskCommand(parseArgs(['task', 'list', '--release', 'active']), ctx)).data),
+      ).toEqual(['TS-4']);
+    });
+
+    it('filters to backlog only', async () => {
+      await seed();
+      expect(
+        listIds((await taskCommand(parseArgs(['task', 'list', '--backlog']), ctx)).data),
+      ).toEqual(['TS-1', 'TS-2']);
+    });
+
+    it('filters by case-insensitive text on title/description', async () => {
+      await seed();
+      expect(
+        listIds((await taskCommand(parseArgs(['task', 'list', '--text', 'SHIP']), ctx)).data),
+      ).toEqual(['TS-4']);
+    });
+
+    it('AND-combines filters', async () => {
+      await seed();
+      expect(
+        listIds(
+          (
+            await taskCommand(
+              parseArgs(['task', 'list', '--status', 'todo', '--type', 'bug']),
+              ctx,
+            )
+          ).data,
+        ),
+      ).toEqual(['TS-1', 'TS-4']);
+      expect(
+        listIds(
+          (
+            await taskCommand(
+              parseArgs(['task', 'list', '--status', 'todo', '--type', 'bug', '--epic', 'bug-audit']),
+              ctx,
+            )
+          ).data,
+        ),
+      ).toEqual(['TS-4']);
+    });
+
+    it('returns an empty list (not an error) when nothing matches', async () => {
+      await seed();
+      const out = await taskCommand(parseArgs(['task', 'list', '--status', 'done', '--type', 'bug']), ctx);
+      expect((out.data as { tasks: unknown[]; count: number }).tasks).toEqual([]);
+      expect((out.data as { count: number }).count).toBe(0);
+    });
+
+    it('rejects an invalid --type with a USAGE error', async () => {
+      await seed();
+      await expect(
+        taskCommand(parseArgs(['task', 'list', '--type', 'nonsense']), ctx),
+      ).rejects.toMatchObject({ code: 'USAGE', exitCode: 2 });
+    });
+
+    it('rejects an unknown --epic with EPIC_NOT_FOUND', async () => {
+      await seed();
+      await expect(
+        taskCommand(parseArgs(['task', 'list', '--epic', 'ghost']), ctx),
+      ).rejects.toMatchObject({ code: 'EPIC_NOT_FOUND' });
+    });
+
+    it('rejects an unknown --release with RELEASE_NOT_FOUND', async () => {
+      await seed();
+      await expect(
+        taskCommand(parseArgs(['task', 'list', '--release', 'ghost']), ctx),
+      ).rejects.toMatchObject({ code: 'RELEASE_NOT_FOUND' });
     });
   });
 });

--- a/packages/cli/src/commands/commands.test.ts
+++ b/packages/cli/src/commands/commands.test.ts
@@ -289,6 +289,44 @@ describe('cli commands (integration)', () => {
       ).toEqual(['TS-4']);
     });
 
+    it('matches --text against the description body, not only the title', async () => {
+      await seed();
+      // "telemetry" appears in no title — a hit proves the description branch.
+      await taskCommand(
+        parseArgs(['task', 'edit', 'TS-1', '--description', 'Investigate telemetry drift']),
+        ctx,
+      );
+      expect(
+        listIds((await taskCommand(parseArgs(['task', 'list', '--text', 'TELEMETRY']), ctx)).data),
+      ).toEqual(['TS-1']);
+    });
+
+    it('accepts the ls alias', async () => {
+      await seed();
+      const viaLs = listIds((await taskCommand(parseArgs(['task', 'ls']), ctx)).data);
+      expect(viaLs).toEqual(['TS-1', 'TS-2', 'TS-3', 'TS-4']);
+    });
+
+    it('renders human output with mark, id, type/status, epic, location and count', async () => {
+      await seed();
+      const out = await taskCommand(parseArgs(['task', 'list', '--release', 'active']), ctx);
+      expect(out.human).toContain('TS-4');
+      expect(out.human).toContain('[bug/todo]');
+      expect(out.human).toContain('epic:bug-audit');
+      expect(out.human).toContain('(release: releases/active.md)');
+      expect(out.human).toContain('Delta ship');
+      expect(out.human).toContain('1 task(s).');
+    });
+
+    it('renders a placeholder line when nothing matches', async () => {
+      await seed();
+      const out = await taskCommand(
+        parseArgs(['task', 'list', '--status', 'done', '--type', 'bug']),
+        ctx,
+      );
+      expect(out.human).toBe('No matching tasks.');
+    });
+
     it('AND-combines filters', async () => {
       await seed();
       expect(

--- a/packages/cli/src/commands/schema.ts
+++ b/packages/cli/src/commands/schema.ts
@@ -29,6 +29,13 @@ const DESCRIPTOR = {
     },
     { name: 'task get', usage: 'boardown task get <id>', summary: 'Show one task and where it lives.' },
     {
+      name: 'task list',
+      usage:
+        'boardown task list [--status STATUS] [--type TYPE] [--epic SLUG] [--release REF] [--backlog] [--text SUBSTR]',
+      summary:
+        'List tasks across the whole board, filtered by any combination of status, type, epic, release, backlog-only, or a case-insensitive text match on title/description. Data is { tasks: [{ task, in: { kind, file } }], count }.',
+    },
+    {
       name: 'task add',
       usage:
         'boardown task add <title> [--type TYPE] [--status STATUS] [--description TEXT] [--epic SLUG] [--release FILE]',

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -17,6 +17,8 @@ import {
   type NewTaskInput,
   type Note,
   type ParseProblem,
+  type Release,
+  type ReleaseStatus,
   type Task,
   type TaskPatch,
   type TaskStatus,
@@ -25,6 +27,7 @@ import {
 import { flagBool, flagString, type ParsedArgs } from '../args';
 import { CliError } from '../output';
 import {
+  epicMembers,
   findEpic,
   findRelease,
   loadBoardOrThrow,
@@ -32,8 +35,10 @@ import {
   resolveBoardRoot,
   writeConfig,
   writeContainer,
+  type ContainerKind,
   type ContainerRef,
 } from '../persistence';
+import { statusMark } from './board';
 import type { CommandContext, CommandHandler, CommandOutput } from '../types';
 
 export const taskCommand: CommandHandler = (args, ctx) => {
@@ -42,6 +47,9 @@ export const taskCommand: CommandHandler = (args, ctx) => {
     case 'get':
     case 'show':
       return taskGet(args, ctx);
+    case 'list':
+    case 'ls':
+      return taskList(args, ctx);
     case 'add':
       return taskAdd(args, ctx);
     case 'edit':
@@ -63,7 +71,7 @@ export const taskCommand: CommandHandler = (args, ctx) => {
     default:
       throw new CliError(
         'USAGE',
-        `Unknown task subcommand "${sub ?? ''}". Use: get | add | edit | status | reorder | rm | checklist | notes.`,
+        `Unknown task subcommand "${sub ?? ''}". Use: get | list | add | edit | status | reorder | rm | checklist | notes.`,
         2,
       );
   }
@@ -75,12 +83,15 @@ const isTaskType = (value: string): value is TaskType =>
 const isTaskStatus = (value: string): value is TaskStatus =>
   (TASK_STATUSES as readonly string[]).includes(value);
 
-function requireType(value: string | undefined, fallback: TaskType): TaskType {
-  if (value === undefined) return fallback;
+function parseTaskType(value: string): TaskType {
   if (!isTaskType(value)) {
     throw new CliError('USAGE', `Invalid --type "${value}" (one of ${TASK_TYPES.join(', ')}).`, 2);
   }
   return value;
+}
+
+function requireType(value: string | undefined, fallback: TaskType): TaskType {
+  return value === undefined ? fallback : parseTaskType(value);
 }
 
 function requireStatus(value: string): TaskStatus {
@@ -417,6 +428,95 @@ async function taskGet(args: ParsedArgs, ctx: CommandContext): Promise<CommandOu
   return {
     data: { task, in: { kind: location.kind, file: location.container.filename } },
     human: renderTask(task, location.kind, location.container.filename),
+    ...problemsField(problems),
+  };
+}
+
+interface TaskListEntry {
+  task: Task;
+  in: { kind: ContainerKind; file: string };
+}
+
+// Flatten every task across the board, each paired with its physical container.
+// Order mirrors the board view (current → future releases, backlog, epics,
+// finished releases) so a filtered list reads in the same order as `board`.
+function collectEntries(snapshot: BoardSnapshot): TaskListEntry[] {
+  const entries: TaskListEntry[] = [];
+  const push = (kind: ContainerKind, filename: string, tasks: readonly Task[]): void => {
+    for (const task of tasks) entries.push({ task, in: { kind, file: filename } });
+  };
+  const releasesByStatus = (status: ReleaseStatus): readonly Release[] =>
+    snapshot.releases.filter((r) => r.frontmatter.status === status);
+
+  for (const r of releasesByStatus('current')) push('release', r.filename, r.tasks);
+  for (const r of releasesByStatus('future')) push('release', r.filename, r.tasks);
+  if (snapshot.backlog) push('backlog', snapshot.backlog.filename, snapshot.backlog.tasks);
+  for (const e of snapshot.epics) push('epic', e.filename, e.tasks);
+  for (const r of releasesByStatus('finished')) push('release', r.filename, r.tasks);
+  return entries;
+}
+
+const renderTaskList = (entries: readonly TaskListEntry[]): string => {
+  if (entries.length === 0) return 'No matching tasks.';
+  const lines = entries.map(({ task, in: loc }) => {
+    const fm = task.frontmatter;
+    const epic = fm.epic !== undefined ? `  epic:${fm.epic}` : '';
+    return `${statusMark(task)} ${fm.id}  [${fm.type}/${fm.status}]${epic}  (${loc.kind}: ${loc.file})  ${task.title}`;
+  });
+  lines.push(`\n${entries.length} task(s).`);
+  return lines.join('\n');
+};
+
+async function taskList(args: ParsedArgs, ctx: CommandContext): Promise<CommandOutput> {
+  const statusFlag = flagString(args.flags, 'status');
+  const typeFlag = flagString(args.flags, 'type');
+  const epicFlag = flagString(args.flags, 'epic');
+  const releaseFlag = flagString(args.flags, 'release');
+  const backlogOnly = flagBool(args.flags, 'backlog');
+  const textFlag = flagString(args.flags, 'text');
+
+  const status = statusFlag !== undefined ? requireStatus(statusFlag) : undefined;
+  const type = typeFlag !== undefined ? parseTaskType(typeFlag) : undefined;
+  const text = textFlag?.toLowerCase();
+
+  const root = await resolveBoardRoot(ctx.cwd, ctx.dataDir);
+  const { snapshot, problems } = await loadBoardOrThrow(root);
+
+  // Unknown --epic / --release is a caller mistake, not an empty result: fail
+  // loud like `task get`, resolving the ref against the loaded board.
+  let epicMemberIds: Set<string> | undefined;
+  if (epicFlag !== undefined) {
+    const epic = findEpic(snapshot, epicFlag);
+    if (epic === undefined) throw new CliError('EPIC_NOT_FOUND', `No epic "${epicFlag}".`);
+    epicMemberIds = new Set(epicMembers(snapshot, epic).map((t) => t.frontmatter.id));
+  }
+  let releaseFile: string | undefined;
+  if (releaseFlag !== undefined) {
+    const release = findRelease(snapshot, releaseFlag);
+    if (release === undefined) throw new CliError('RELEASE_NOT_FOUND', `No release "${releaseFlag}".`);
+    releaseFile = release.filename;
+  }
+
+  const entries = collectEntries(snapshot).filter(({ task, in: loc }) => {
+    const fm = task.frontmatter;
+    if (status !== undefined && fm.status !== status) return false;
+    if (type !== undefined && fm.type !== type) return false;
+    if (epicMemberIds !== undefined && !epicMemberIds.has(fm.id)) return false;
+    if (releaseFile !== undefined && !(loc.kind === 'release' && loc.file === releaseFile)) return false;
+    if (backlogOnly && loc.kind !== 'backlog') return false;
+    if (
+      text !== undefined &&
+      !task.title.toLowerCase().includes(text) &&
+      !task.description.toLowerCase().includes(text)
+    ) {
+      return false;
+    }
+    return true;
+  });
+
+  return {
+    data: { tasks: entries, count: entries.length },
+    human: renderTaskList(entries),
     ...problemsField(problems),
   };
 }


### PR DESCRIPTION
## What

Adds a filterable task listing to the CLI: `boardown task list` (alias `ls`) with
`--status`, `--type`, `--epic`, `--release`, `--backlog` and `--text` filters,
AND-combined over the loaded board snapshot. This lets agents and scripts select a
subset of tasks on large boards instead of only `task get <id>` or a full `board` dump.

## How

- Flattens every task paired with its physical container, ordered like the board
  view (current → future releases, backlog, epics, finished) so a filtered list
  reads in the same order as `board`.
- `--epic` resolves membership via core `epicMembers` (epic tag + tasks physically
  in the epic file); unknown `--epic`/`--release` fail loud
  (`EPIC_NOT_FOUND`/`RELEASE_NOT_FOUND`), invalid `--status`/`--type` are `USAGE`
  errors (exit 2). Empty result is a normal `ok: true, count: 0`.
- Output mirrors `task get`: JSON envelope `{ tasks: [{ task, in: { kind, file } }], count }`
  off-TTY / `--json`, flat human lines otherwise.

## Scope

Implemented **entirely in the CLI shell** — `core`/`ui` untouched. Reuses the
exported `statusMark` from the board renderer and a shared `parseTaskType` primitive.

## Tests

- 14 new Vitest cases: each filter in isolation, AND-combination, empty result,
  invalid `--status`/`--type` (USAGE/exit 2), unknown `--epic`/`--release`
  (`*_NOT_FOUND`/exit 1).
- Full gates green (`pnpm lint && pnpm typecheck && pnpm build && pnpm test`).
- e2e smoke on the real esbuild bundle against a live board.
- Help, `schema` descriptor and `packages/cli/README.md` updated.