### PR TITLE
fix(cli): refuse to write a container that would lose a broken task

### DIFF
--- a/packages/cli/src/app.test.ts
+++ b/packages/cli/src/app.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { EPIC_NAME_MAX_LENGTH } from '@boardown/core';
@@ -177,6 +177,168 @@ describe('run() — routing, envelopes, exit codes', () => {
     it('--json forces the JSON envelope even under a TTY', async () => {
       const { stdout } = await capture(['backlog', '--json'], { cwd: project, tty: true });
       expect(parse(stdout)).toMatchObject({ ok: true });
+    });
+  });
+
+  // A task block with unreadable frontmatter is dropped by the parser
+  // (never lands in the container's `tasks` array), so serializing that
+  // container back to disk would silently lose it. Writing to that file must
+  // refuse instead, leaving the file exactly as it was.
+  describe('writing a file with a broken task block', () => {
+    let project: string;
+    let releaseSlug: string;
+    let releaseFile: string;
+
+    beforeEach(async () => {
+      project = await mkdtemp(join(tmpdir(), 'bd-cli-run-broken-'));
+      expect((await capture(['init', '--id-prefix', 'TS', '--project-name', 'Demo'], { cwd: project })).code).toBe(0);
+      const added = await capture(['release', 'add', 'Active'], { cwd: project });
+      expect(added.code).toBe(0);
+      releaseSlug = (parse(added.stdout).data as { slug: string }).slug;
+      releaseFile = join(project, '.boardown', 'releases', `${releaseSlug}.md`);
+
+      // Corrupt the release file by hand: valid file frontmatter, but a task
+      // block whose YAML frontmatter fails to parse.
+      const original = await readFile(releaseFile, 'utf8');
+      await writeFile(
+        releaseFile,
+        `${original}\n## Broken task\n\n---\nid: [unterminated\n---\n\nbody\n`,
+        'utf8',
+      );
+    });
+
+    afterEach(async () => {
+      await rm(project, { recursive: true, force: true });
+    });
+
+    it('refuses the write with a non-zero exit code and leaves the file untouched', async () => {
+      const before = await readFile(releaseFile, 'utf8');
+
+      const { code, stdout } = await capture(
+        ['task', 'add', 'New task', '--release', releaseSlug],
+        { cwd: project },
+      );
+
+      expect(code).not.toBe(0);
+      const env = parse(stdout);
+      expect(env.ok).toBe(false);
+      expect(errorCode(env)).toBe('UNREADABLE_FRONTMATTER');
+
+      const after = await readFile(releaseFile, 'utf8');
+      expect(after).toBe(before);
+      expect(after).toContain('id: [unterminated');
+    });
+  });
+
+  // Same class of bug, second door: an epic file can also hold task blocks
+  // (unscheduled tasks), and `epic edit` writes the file back too.
+  describe('editing an epic file with a broken task block', () => {
+    let project: string;
+    let epicSlug: string;
+    let epicFile: string;
+
+    beforeEach(async () => {
+      project = await mkdtemp(join(tmpdir(), 'bd-cli-run-broken-epic-'));
+      expect((await capture(['init', '--id-prefix', 'TS', '--project-name', 'Demo'], { cwd: project })).code).toBe(0);
+      const added = await capture(['epic', 'add', 'UI'], { cwd: project });
+      expect(added.code).toBe(0);
+      epicSlug = (parse(added.stdout).data as { slug: string }).slug;
+      epicFile = join(project, '.boardown', 'epics', `${epicSlug}.md`);
+
+      const original = await readFile(epicFile, 'utf8');
+      await writeFile(
+        epicFile,
+        `${original}\n## Broken task\n\n---\nid: [unterminated\n---\n\nbody\n`,
+        'utf8',
+      );
+    });
+
+    afterEach(async () => {
+      await rm(project, { recursive: true, force: true });
+    });
+
+    it('refuses the write with a non-zero exit code and leaves the file untouched', async () => {
+      const before = await readFile(epicFile, 'utf8');
+
+      const { code, stdout } = await capture(['epic', 'edit', epicSlug, '--name', 'UI Renamed'], {
+        cwd: project,
+      });
+
+      expect(code).not.toBe(0);
+      const env = parse(stdout);
+      expect(env.ok).toBe(false);
+      expect(errorCode(env)).toBe('UNREADABLE_FRONTMATTER');
+
+      const after = await readFile(epicFile, 'utf8');
+      expect(after).toBe(before);
+      expect(after).toContain('id: [unterminated');
+    });
+  });
+
+  // Third and fourth doors onto the same file class: `release edit` (in-place,
+  // and the rename path via moveFile) and `release start` also write a
+  // release container back to disk outside writeContainer's original call sites.
+  describe('writing a release file with a broken task block', () => {
+    let project: string;
+    let releaseSlug: string;
+    let releaseFile: string;
+
+    beforeEach(async () => {
+      project = await mkdtemp(join(tmpdir(), 'bd-cli-run-broken-rel2-'));
+      expect((await capture(['init', '--id-prefix', 'TS', '--project-name', 'Demo'], { cwd: project })).code).toBe(0);
+      const added = await capture(['release', 'add', 'Active'], { cwd: project });
+      expect(added.code).toBe(0);
+      releaseSlug = (parse(added.stdout).data as { slug: string }).slug;
+      releaseFile = join(project, '.boardown', 'releases', `${releaseSlug}.md`);
+
+      const original = await readFile(releaseFile, 'utf8');
+      await writeFile(
+        releaseFile,
+        `${original}\n## Broken task\n\n---\nid: [unterminated\n---\n\nbody\n`,
+        'utf8',
+      );
+    });
+
+    afterEach(async () => {
+      await rm(project, { recursive: true, force: true });
+    });
+
+    it('release edit (in-place) refuses and leaves the file untouched', async () => {
+      const before = await readFile(releaseFile, 'utf8');
+
+      const { code, stdout } = await capture(
+        ['release', 'edit', releaseSlug, '--description', 'updated'],
+        { cwd: project },
+      );
+
+      expect(code).not.toBe(0);
+      expect(errorCode(parse(stdout))).toBe('UNREADABLE_FRONTMATTER');
+      expect(await readFile(releaseFile, 'utf8')).toBe(before);
+    });
+
+    it('release edit --name (rename, moveFile path) refuses and leaves the file untouched', async () => {
+      const before = await readFile(releaseFile, 'utf8');
+
+      const { code, stdout } = await capture(
+        ['release', 'edit', releaseSlug, '--name', 'Renamed Active'],
+        { cwd: project },
+      );
+
+      expect(code).not.toBe(0);
+      expect(errorCode(parse(stdout))).toBe('UNREADABLE_FRONTMATTER');
+      expect(await readFile(releaseFile, 'utf8')).toBe(before);
+      const renamedFile = join(project, '.boardown', 'releases', 'renamed-active.md');
+      await expect(readFile(renamedFile, 'utf8')).rejects.toThrow();
+    });
+
+    it('release start refuses and leaves the file untouched', async () => {
+      const before = await readFile(releaseFile, 'utf8');
+
+      const { code, stdout } = await capture(['release', 'start', releaseSlug], { cwd: project });
+
+      expect(code).not.toBe(0);
+      expect(errorCode(parse(stdout))).toBe('UNREADABLE_FRONTMATTER');
+      expect(await readFile(releaseFile, 'utf8')).toBe(before);
     });
   });
 });

--- a/packages/cli/src/commands/commands.test.ts
+++ b/packages/cli/src/commands/commands.test.ts
@@ -612,7 +612,9 @@ describe('cli commands (integration)', () => {
         .map((container): ContainerRef => ({ kind: 'epic', container })),
     ];
 
-    await expect(writeContainers(board.fs, refs)).rejects.toMatchObject({ code: 'CONFLICT' });
+    await expect(writeContainers(board.fs, refs, board.problems)).rejects.toMatchObject({
+      code: 'CONFLICT',
+    });
 
     // The release is written first, so a sequence of single writes would already
     // have finished it here.

--- a/packages/cli/src/commands/epic.ts
+++ b/packages/cli/src/commands/epic.ts
@@ -2,7 +2,6 @@ import {
   EPIC_NAME_MAX_LENGTH,
   createEpic,
   editEpic,
-  serializeEpic,
   sortTasksByOrder,
   type Epic,
   type EpicPatch,
@@ -16,6 +15,7 @@ import {
   findEpic,
   loadBoardOrThrow,
   resolveBoardRoot,
+  writeContainer,
   type LoadedBoard,
 } from '../persistence';
 import type { CommandContext, CommandHandler, CommandOutput } from '../types';
@@ -137,7 +137,7 @@ async function epicAdd(args: ParsedArgs, ctx: CommandContext): Promise<CommandOu
     throw new CliError('EPIC_INVALID', err instanceof Error ? err.message : String(err), 2);
   }
 
-  await board.fs.write(epic.filename, serializeEpic(epic));
+  await writeContainer(board.fs, { kind: 'epic', container: epic }, board.problems);
   return {
     data: { slug: epic.slug },
     human: `Created epic "${epic.frontmatter.name}" (${epic.slug}).`,
@@ -191,7 +191,7 @@ async function epicEdit(args: ParsedArgs, ctx: CommandContext): Promise<CommandO
     throw new CliError('EPIC_INVALID', err instanceof Error ? err.message : String(err), 2);
   }
 
-  await board.fs.write(updated.filename, serializeEpic(updated));
+  await writeContainer(board.fs, { kind: 'epic', container: updated }, board.problems);
   return {
     data: { slug: updated.slug },
     human: `Updated epic ${slug}.`,

--- a/packages/cli/src/commands/release.ts
+++ b/packages/cli/src/commands/release.ts
@@ -5,7 +5,6 @@ import {
   createRelease,
   editRelease,
   emptyBacklog,
-  serializeRelease,
   sortTasksByOrder,
   startRelease,
   type BoardConfig,
@@ -20,8 +19,10 @@ import { isFull, summaryLines, taskPayload, summarizeTasks } from '../summary';
 import {
   findRelease,
   loadBoardOrThrow,
+  moveContainer,
   resolveBoardRoot,
   writeConfig,
+  writeContainer,
   writeContainers,
   type ContainerRef,
   type LoadedBoard,
@@ -186,7 +187,7 @@ async function releaseAdd(args: ParsedArgs, ctx: CommandContext): Promise<Comman
     throw new CliError('RELEASE_INVALID', err instanceof Error ? err.message : String(err), 2);
   }
 
-  await board.fs.write(release.filename, serializeRelease(release));
+  await writeContainer(board.fs, { kind: 'release', container: release }, board.problems);
   return {
     data: { slug: release.slug },
     human: `Created release "${releaseName(release)}" (${release.filename}).`,
@@ -232,10 +233,17 @@ async function releaseEdit(args: ParsedArgs, ctx: CommandContext): Promise<Comma
     throw new CliError('RELEASE_INVALID', message, 2);
   }
 
-  const content = serializeRelease(updated);
   const moved = updated.filename !== release.filename;
-  if (moved) await board.fs.moveFile(release.filename, updated.filename, content);
-  else await board.fs.write(updated.filename, content);
+  if (moved) {
+    await moveContainer(
+      board.fs,
+      { kind: 'release', container: updated },
+      release.filename,
+      board.problems,
+    );
+  } else {
+    await writeContainer(board.fs, { kind: 'release', container: updated }, board.problems);
+  }
 
   // The Board's stored choice is a slug, so a rename carries it. After the move,
   // never with it: a slug that fell behind resolves to the first active release,
@@ -270,7 +278,7 @@ async function releaseStart(args: ParsedArgs, ctx: CommandContext): Promise<Comm
     throw new CliError('RELEASE_CONFLICT', err instanceof Error ? err.message : String(err));
   }
 
-  await board.fs.write(started.filename, serializeRelease(started));
+  await writeContainer(board.fs, { kind: 'release', container: started }, board.problems);
   return {
     data: { slug: started.slug },
     human: `Started release ${releaseName(started)} (now current).`,
@@ -319,7 +327,7 @@ async function releaseDone(args: ParsedArgs, ctx: CommandContext): Promise<Comma
   if (result.backlog !== null && changed.has(result.backlog.filename)) {
     refs.push({ kind: 'backlog', container: result.backlog });
   }
-  await writeContainers(board.fs, refs);
+  await writeContainers(board.fs, refs, board.problems);
 
   return {
     data: { slug: result.release.slug },

--- a/packages/cli/src/commands/task.ts
+++ b/packages/cli/src/commands/task.ts
@@ -263,7 +263,7 @@ async function taskAdd(args: ParsedArgs, ctx: CommandContext): Promise<CommandOu
   };
 
   const result = applyOp(() => createTask(target.container, snapshot.config, input));
-  await writeContainer(fs, { kind: target.kind, container: result.container });
+  await writeContainer(fs, { kind: target.kind, container: result.container }, problems);
   await writeConfig(fs, result.config);
 
   return {
@@ -327,7 +327,7 @@ async function moveAndReport(
   newStatus?: TaskStatus,
 ): Promise<CommandOutput> {
   if (edited.filename === dest.container.filename) {
-    await writeContainer(fs, { kind: location.kind, container: edited });
+    await writeContainer(fs, { kind: location.kind, container: edited }, problems);
     return { data: { id: taskId }, human: `Updated ${taskId}.`, ...problemsField(problems) };
   }
   const movingTask = edited.tasks.find((t) => t.frontmatter.id === taskId);
@@ -341,8 +341,8 @@ async function moveAndReport(
       destEpic: dest.destEpic,
     }),
   );
-  await writeContainer(fs, { kind: location.kind, container: result.source });
-  await writeContainer(fs, { kind: dest.kind, container: result.dest });
+  await writeContainer(fs, { kind: location.kind, container: result.source }, problems);
+  await writeContainer(fs, { kind: dest.kind, container: result.dest }, problems);
   return {
     data: { id: taskId },
     human: `Updated ${taskId}; moved to ${result.dest.filename}.`,
@@ -422,7 +422,7 @@ async function taskEdit(args: ParsedArgs, ctx: CommandContext): Promise<CommandO
       ? applyOp(() => editTask(location.container, snapshot.config, id, patch))
       : location.container;
     if (dest === null) {
-      await writeContainer(fs, { kind: location.kind, container: edited });
+      await writeContainer(fs, { kind: location.kind, container: edited }, problems);
       return { data: { id }, human: `Updated ${id}.`, ...problemsField(problems) };
     }
     return moveAndReport(fs, snapshot.config, location, edited, dest, id, problems, movedStatus);
@@ -460,7 +460,7 @@ async function taskEdit(args: ParsedArgs, ctx: CommandContext): Promise<CommandO
   const patch: TaskPatch = { ...fields };
   if (nextEpic !== undefined) patch.epic = nextEpic;
   const edited = applyOp(() => editTask(location.container, snapshot.config, id, patch));
-  await writeContainer(fs, { kind: location.kind, container: edited });
+  await writeContainer(fs, { kind: location.kind, container: edited }, problems);
   return { data: { id }, human: `Updated ${id}.`, ...problemsField(problems) };
 }
 
@@ -479,7 +479,7 @@ async function taskStatus(args: ParsedArgs, ctx: CommandContext): Promise<Comman
   }
 
   const updated = applyOp(() => changeTaskStatus(location.container, snapshot.config, id, status));
-  await writeContainer(fs, { kind: location.kind, container: updated });
+  await writeContainer(fs, { kind: location.kind, container: updated }, problems);
 
   return { data: { id }, human: `${id} → ${status}.`, ...problemsField(problems) };
 }
@@ -741,7 +741,7 @@ async function taskReorder(args: ParsedArgs, ctx: CommandContext): Promise<Comma
   }
 
   const updated = applyOp(() => reorderTask(location.container, id, beforeTaskId));
-  await writeContainer(fs, { kind: location.kind, container: updated });
+  await writeContainer(fs, { kind: location.kind, container: updated }, problems);
 
   return {
     data: { id },
@@ -781,7 +781,7 @@ async function taskRm(args: ParsedArgs, ctx: CommandContext): Promise<CommandOut
   const changed = result.containers
     .map((container, i): ContainerRef => ({ kind: refs[i]!.kind, container }))
     .filter((ref) => result.changedFilenames.includes(ref.container.filename));
-  await writeContainers(fs, changed);
+  await writeContainers(fs, changed, problems);
 
   return {
     data: { id },
@@ -817,7 +817,7 @@ async function mutateTask(
 
   const { patch, human, extra } = build(task);
   const edited = applyOp(() => editTask(location.container, snapshot.config, taskId, patch));
-  await writeContainer(fs, { kind: location.kind, container: edited });
+  await writeContainer(fs, { kind: location.kind, container: edited }, problems);
 
   return {
     data: { id: taskId, ...(extra ?? {}) },
@@ -1107,7 +1107,7 @@ async function linkMutate(
       : { kind: target.kind, container: result.target },
   );
   if (refs.length > 0) {
-    await writeContainers(fs, refs);
+    await writeContainers(fs, refs, problems);
   }
 
   // Naming the relation matters once there are seven of them: "Unlinked A and B"

--- a/packages/cli/src/persistence.test.ts
+++ b/packages/cli/src/persistence.test.ts
@@ -1,0 +1,125 @@
+import {
+  createGuardedFs,
+  emptyBacklog,
+  type FileStat,
+  type FsAdapter,
+  type FsEntry,
+  type ParseProblem,
+} from '@boardown/core';
+import { describe, expect, it } from 'vitest';
+import { CliError } from './output';
+import { writeContainer, writeContainers, type ContainerRef } from './persistence';
+
+class InMemoryFs implements FsAdapter {
+  files = new Map<string, string>();
+  async read(path: string): Promise<string> {
+    const content = this.files.get(path);
+    if (content === undefined) throw new Error(`ENOENT: ${path}`);
+    return content;
+  }
+  async write(path: string, content: string): Promise<void> {
+    this.files.set(path, content);
+  }
+  async list(): Promise<FsEntry[]> {
+    return [];
+  }
+  async stat(): Promise<FileStat | null> {
+    return null;
+  }
+  async mkdir(): Promise<void> {}
+  async remove(path: string): Promise<void> {
+    this.files.delete(path);
+  }
+}
+
+const backlogRef = (): ContainerRef => ({ kind: 'backlog', container: emptyBacklog() });
+
+describe('writeContainer', () => {
+  it('writes normally when there are no problems for the file', async () => {
+    const fs = new InMemoryFs();
+    const ref = backlogRef();
+    await writeContainer(fs, ref, []);
+    expect(fs.files.has(ref.container.filename)).toBe(true);
+  });
+
+  it('writes normally when problems exist for a different file', async () => {
+    const fs = new InMemoryFs();
+    const ref = backlogRef();
+    const problems: ParseProblem[] = [
+      { level: 'error', scope: 'task', file: 'releases/other.md', taskIndex: 0, message: 'bad' },
+    ];
+    await writeContainer(fs, ref, problems);
+    expect(fs.files.has(ref.container.filename)).toBe(true);
+  });
+
+  it('refuses to write a file with an unresolved task-level parse error', async () => {
+    const fs = new InMemoryFs();
+    const ref = backlogRef();
+    const problems: ParseProblem[] = [
+      {
+        level: 'error',
+        scope: 'task',
+        file: ref.container.filename,
+        taskIndex: 1,
+        message: 'Invalid task frontmatter YAML: bad indentation',
+      },
+    ];
+
+    await expect(writeContainer(fs, ref, problems)).rejects.toMatchObject({
+      code: 'UNREADABLE_FRONTMATTER',
+    });
+    expect(fs.files.has(ref.container.filename)).toBe(false);
+  });
+
+  it('does not refuse on a warning-level problem for the same file', async () => {
+    const fs = new InMemoryFs();
+    const ref = backlogRef();
+    const problems: ParseProblem[] = [
+      { level: 'warning', scope: 'file', file: ref.container.filename, message: 'heads up' },
+    ];
+    await writeContainer(fs, ref, problems);
+    expect(fs.files.has(ref.container.filename)).toBe(true);
+  });
+
+  it('carries the matching problems on the thrown error', async () => {
+    const fs = new InMemoryFs();
+    const ref = backlogRef();
+    const problem: ParseProblem = {
+      level: 'error',
+      scope: 'task',
+      file: ref.container.filename,
+      taskIndex: 0,
+      message: 'broken',
+    };
+
+    try {
+      await writeContainer(fs, ref, [problem]);
+      expect.unreachable();
+    } catch (err) {
+      expect(err).toBeInstanceOf(CliError);
+      expect((err as CliError).problems).toEqual([problem]);
+    }
+  });
+});
+
+describe('writeContainers', () => {
+  it('refuses the whole batch if any target has an unresolved parse error, writing nothing', async () => {
+    const inner = new InMemoryFs();
+    const fs = createGuardedFs(inner, {}, () => {
+      throw new Error('unexpected conflict');
+    });
+    const ok = backlogRef();
+    const broken: ContainerRef = {
+      kind: 'backlog',
+      container: { ...emptyBacklog(), filename: 'broken.md' },
+    };
+    const problems: ParseProblem[] = [
+      { level: 'error', scope: 'task', file: broken.container.filename, taskIndex: 0, message: 'bad' },
+    ];
+
+    await expect(writeContainers(fs, [ok, broken], problems)).rejects.toMatchObject({
+      code: 'UNREADABLE_FRONTMATTER',
+    });
+    expect(inner.files.size).toBe(0);
+  });
+});

--- a/packages/cli/src/persistence.ts
+++ b/packages/cli/src/persistence.ts
@@ -138,17 +138,54 @@ export function serializeContainer(ref: ContainerRef): string {
   }
 }
 
-export async function writeContainer(fs: FsAdapter, ref: ContainerRef): Promise<void> {
+// A task with unreadable frontmatter never made it into the container's
+// `tasks` array (see parser.ts), so serializing that container drops it
+// silently. Refuse instead of writing a file that would lose the block.
+function assertWritable(problems: readonly ParseProblem[], file: string): void {
+  const matching = problems.filter((p) => p.file === file && p.level === 'error');
+  if (matching.length === 0) return;
+  throw new CliError(
+    'UNREADABLE_FRONTMATTER',
+    `Refusing to write ${file}: it contains a task with unreadable frontmatter that would be lost. Fix or remove the broken block by hand, then retry.`,
+    1,
+    matching,
+  );
+}
+
+export async function writeContainer(
+  fs: FsAdapter,
+  ref: ContainerRef,
+  problems: readonly ParseProblem[],
+): Promise<void> {
+  assertWritable(problems, ref.container.filename);
   await fs.write(ref.container.filename, serializeContainer(ref));
 }
 
 // Containers that must land together (a link mirrored into two tasks): the guard
 // checks every target before writing any of them, so an external change aborts the
 // whole operation instead of half-applying it.
-export async function writeContainers(fs: GuardedFs, refs: ContainerRef[]): Promise<void> {
+export async function writeContainers(
+  fs: GuardedFs,
+  refs: ContainerRef[],
+  problems: readonly ParseProblem[],
+): Promise<void> {
+  for (const ref of refs) assertWritable(problems, ref.container.filename);
   await fs.writeAll(
     refs.map((ref) => ({ path: ref.container.filename, content: serializeContainer(ref) })),
   );
+}
+
+// A rename (e.g. a release renamed to a new slug): the content being moved was
+// parsed from `fromFilename`, so that is where a lost broken block would have
+// come from — same guard as writeContainer, checked against the old path.
+export async function moveContainer(
+  fs: GuardedFs,
+  ref: ContainerRef,
+  fromFilename: string,
+  problems: readonly ParseProblem[],
+): Promise<void> {
+  assertWritable(problems, fromFilename);
+  await fs.moveFile(fromFilename, ref.container.filename, serializeContainer(ref));
 }
 
 export async function writeConfig(fs: FsAdapter, config: BoardConfig): Promise<void> {


### PR DESCRIPTION
## Summary

A task whose frontmatter fails to parse never enters the container's `tasks` array (see `parser.ts`). Serializing and writing that container back to disk therefore silently drops the block — the task is gone and nothing indicates it.

This guards every write path in `persistence.ts` (`writeContainer`, `writeContainers`, and the rename path used e.g. when a release is renamed) against the collected parse problems for that file, and refuses to write with a new `UNREADABLE_FRONTMATTER` error naming the offending file, instead of writing silently.

## Test plan

- [x] Added coverage in `packages/cli/src/persistence.test.ts` for the new guard on all three write paths
- [x] Added coverage in `packages/cli/src/app.test.ts` for the CLI-level behavior (refuse + error surfaced, message names the file)
- [x] Full `@grinev/boardown-cli` test suite passes on top of current `main` (194/194)